### PR TITLE
Add 'deleted' field to Team model and implement CRUD operations for t…

### DIFF
--- a/api/prisma/migrations/20250831215826_add_deleted_to_team/migration.sql
+++ b/api/prisma/migrations/20250831215826_add_deleted_to_team/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Team" ADD COLUMN     "deleted" BOOLEAN NOT NULL DEFAULT false;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -862,6 +862,7 @@ model Team {
   maxSize       Int?
   registrations Registration[]
 
+  deleted Boolean @default(false)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }

--- a/api/routes/events/[eventId]/registration/team/[teamId].js
+++ b/api/routes/events/[eventId]/registration/team/[teamId].js
@@ -1,0 +1,99 @@
+import { verifyAuth } from "#verifyAuth";
+import { prisma } from "#prisma";
+import { teamSchema } from "./index";
+import { zerialize } from "zodex";
+
+export const get = [
+  verifyAuth(["manager"]),
+  async (req, res) => {
+    const { eventId, teamId } = req.params;
+    const team = await prisma.team.findFirst({
+      where: {
+        id: teamId,
+        eventId,
+        instanceId: req.instanceId,
+        deleted: false,
+      },
+      include: {
+        registrations: {
+          where: { finalized: true, instanceId: req.instanceId },
+          select: { id: true },
+        },
+      },
+    });
+    if (!team) return res.status(404).json({ message: "Team not found" });
+    return res.json({
+      team: { ...team, memberCount: team.registrations.length },
+    });
+  },
+];
+
+export const put = [
+  verifyAuth(["manager"]),
+  async (req, res) => {
+    const { eventId, teamId } = req.params;
+
+    const parse = teamSchema.safeParse(req.body);
+    if (!parse.success) {
+      return res.status(400).json({ message: parse.error.format() });
+    }
+    const { name, code, maxSize } = parse.data;
+
+    const before = await prisma.team.findFirst({
+      where: {
+        id: teamId,
+        eventId,
+        instanceId: req.instanceId,
+        deleted: false,
+      },
+    });
+    if (!before) return res.status(404).json({ message: "Team not found" });
+
+    try {
+      // If code is provided and non-empty, update it; if blank/undefined, preserve existing code
+      let codeToUse = (code ?? "").trim();
+      if (!codeToUse) codeToUse = before.code; // keep existing
+
+      const team = await prisma.team.update({
+        where: { id: teamId },
+        data: {
+          name,
+          code: codeToUse,
+          maxSize: maxSize ?? null,
+        },
+      });
+      return res.json({ team });
+    } catch (e) {
+      if (e?.code === "P2002") {
+        return res.status(400).json({
+          message: { code: { _errors: ["Code must be unique"] } },
+        });
+      }
+      return res.status(500).json({ message: e.message });
+    }
+  },
+];
+
+export const del = [
+  verifyAuth(["manager"]),
+  async (req, res) => {
+    const { eventId, teamId } = req.params;
+    const before = await prisma.team.findFirst({
+      where: {
+        id: teamId,
+        eventId,
+        instanceId: req.instanceId,
+        deleted: false,
+      },
+    });
+    if (!before) return res.status(404).json({ message: "Team not found" });
+
+    const team = await prisma.team.update({
+      where: { id: teamId },
+      data: { deleted: true },
+    });
+    return res.json({ team });
+  },
+];
+
+export const query = [(req, res) => res.json(zerialize(teamSchema))];

--- a/api/routes/events/[eventId]/registration/team/index.js
+++ b/api/routes/events/[eventId]/registration/team/index.js
@@ -1,0 +1,106 @@
+import { verifyAuth } from "#verifyAuth";
+import { prisma } from "#prisma";
+import { z } from "zod";
+import { zerialize } from "zodex";
+import { generateTeamCode } from "#util/generateTeamCode";
+
+export const teamSchema = z.object({
+  name: z.string().min(2).max(64),
+  // Optional; empty string allowed and triggers auto-generation
+  code: z.string().min(2).max(32).optional().or(z.literal("")),
+  maxSize: z.number().int().min(1).nullable().optional(),
+});
+
+export const post = [
+  verifyAuth(["manager"]),
+  async (req, res) => {
+    const result = teamSchema.safeParse(req.body);
+    if (!result.success) {
+      return res.status(400).json({ message: result.error.format() });
+    }
+
+    const { eventId } = req.params;
+    const { name, code, maxSize } = result.data;
+
+    // Use provided code or auto-generate an 8-char code from allowed characters
+    let codeToUse = (code || "").trim();
+    if (!codeToUse) codeToUse = generateTeamCode(8);
+
+    try {
+      let team;
+      // Retry a few times on unique conflicts with generated codes
+      for (let i = 0; i < 5; i++) {
+        try {
+          team = await prisma.team.create({
+            data: {
+              name,
+              code: codeToUse,
+              maxSize: maxSize ?? null,
+              event: { connect: { id: eventId } },
+              instance: { connect: { id: req.instanceId } },
+            },
+          });
+          break; // success
+        } catch (e) {
+          if (e?.code === "P2002" && !code) {
+            // only retry if we auto-generated or user left blank
+            codeToUse = generateTeamCode(8);
+            continue;
+          }
+          throw e;
+        }
+      }
+      if (!team) throw new Error("Failed to create unique team code");
+
+      // Return full list for convenience
+      const teams = await prisma.team.findMany({
+        where: { eventId, instanceId: req.instanceId, deleted: false },
+        include: {
+          registrations: {
+            where: { finalized: true, instanceId: req.instanceId },
+            select: { id: true },
+          },
+        },
+        orderBy: { createdAt: "asc" },
+      });
+
+      const enriched = teams.map((t) => ({
+        ...t,
+        memberCount: t.registrations.length,
+      }));
+
+      return res.status(201).json({ team, teams: enriched });
+    } catch (e) {
+      // Handle unique constraint on code
+      if (e?.code === "P2002") {
+        return res.status(400).json({
+          message: { code: { _errors: ["Code must be unique"] } },
+        });
+      }
+      return res.status(500).json({ message: e.message });
+    }
+  },
+];
+
+export const get = [
+  verifyAuth(["manager"]),
+  async (req, res) => {
+    const { eventId } = req.params;
+    const teams = await prisma.team.findMany({
+      where: { eventId, instanceId: req.instanceId, deleted: false },
+      include: {
+        registrations: {
+          where: { finalized: true, instanceId: req.instanceId },
+          select: { id: true },
+        },
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    return res.json({
+      teams: teams.map((t) => ({ ...t, memberCount: t.registrations.length })),
+    });
+  },
+];
+
+export const query = [(req, res) => res.json(zerialize(teamSchema))];

--- a/api/util/generateTeamCode.js
+++ b/api/util/generateTeamCode.js
@@ -1,0 +1,10 @@
+export const generateTeamCode = (length = 8) => {
+  const CHARS = "ACFHJKLPRTUVXY24579";
+  let code = "";
+  for (let i = 0; i < length; i++) {
+    const idx = Math.floor(Math.random() * CHARS.length);
+    code += CHARS[idx];
+  }
+  return code;
+};
+

--- a/app/components/TeamCRUD/TeamCRUD.jsx
+++ b/app/components/TeamCRUD/TeamCRUD.jsx
@@ -1,0 +1,118 @@
+import { Typography, Input, Checkbox, Button } from "tabler-react-2";
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { Loading } from "../loading/Loading";
+import { useRegistrationTeams } from "../../hooks/useRegistrationTeams";
+import { useRegistrationTeam } from "../../hooks/useRegistrationTeam";
+
+export const TeamCRUD = ({ team, onClose, ...props }) => {
+  if (team?.id) {
+    return <TeamEdit teamId={team.id} onClose={onClose} {...props} />;
+  }
+  return <TeamCreate onClose={onClose} {...props} />;
+};
+
+const TeamCreate = ({ onClose }) => {
+  const { eventId } = useParams();
+  const { mutationLoading, createTeam, validationError } =
+    useRegistrationTeams({ eventId });
+
+  return (
+    <_TeamCRUD
+      value={null}
+      onClose={onClose}
+      mutationLoading={mutationLoading}
+      validationError={validationError}
+      onFinish={createTeam}
+    />
+  );
+};
+
+const TeamEdit = ({ teamId, onClose }) => {
+  const { eventId } = useParams();
+  const { team, loading, mutationLoading, validationError, updateTeam } =
+    useRegistrationTeam({ eventId, teamId });
+
+  if (loading) return <Loading />;
+
+  return (
+    <_TeamCRUD
+      value={team}
+      onClose={onClose}
+      mutationLoading={mutationLoading}
+      validationError={validationError}
+      onFinish={updateTeam}
+    />
+  );
+};
+
+const _TeamCRUD = ({ value, onClose, mutationLoading, validationError, onFinish }) => {
+  const [team, setTeam] = useState(value || { maxSize: null });
+  const [limitSize, setLimitSize] = useState(Boolean(value?.maxSize));
+
+  useEffect(() => {
+    setTeam(value || { maxSize: null });
+    setLimitSize(Boolean(value?.maxSize));
+  }, [value]);
+
+  const handleSubmit = async () => {
+    const payload = {
+      name: team.name,
+      code: team.code,
+      maxSize: limitSize ? parseInt(team.maxSize ?? 1, 10) : null,
+    };
+    if (await onFinish(payload)) onClose?.();
+  };
+
+  return (
+    <div>
+      <Typography.H5 className="mb-0 text-secondary">TEAM</Typography.H5>
+      <Typography.H1>{value?.name || "New Team"}</Typography.H1>
+
+      <Input
+        label="Name"
+        value={team.name}
+        onChange={(e) => setTeam({ ...team, name: e })}
+        required
+        placeholder="Name your team..."
+        invalid={validationError?.name?._errors?.length > 0}
+        invalidText={validationError?.name?._errors?.[0]}
+      />
+
+      <Input
+        label="Code"
+        value={team.code}
+        onChange={(e) => setTeam({ ...team, code: e })}
+        placeholder="Optional — auto-generated if blank"
+        invalid={validationError?.code?._errors?.length > 0}
+        invalidText={validationError?.code?._errors?.[0]}
+      />
+
+      <label className="form-label">Team Size</label>
+      <Checkbox
+        label="Limit team size"
+        value={limitSize}
+        onChange={(e) => {
+          setLimitSize(e);
+          if (!e) setTeam({ ...team, maxSize: null });
+          else if (!team.maxSize) setTeam({ ...team, maxSize: 1 });
+        }}
+      />
+      {limitSize && (
+        <Input
+          value={team.maxSize}
+          onChange={(e) => setTeam({ ...team, maxSize: parseInt(e, 10) })}
+          type="number"
+          min={1}
+          appendedText="members"
+          invalid={validationError?.maxSize?._errors?.length > 0}
+          invalidText={validationError?.maxSize?._errors?.[0]}
+        />
+      )}
+
+      <Button onClick={handleSubmit} loading={mutationLoading} variant="primary">
+        {team.id ? "Update" : "Create"} Team
+      </Button>
+    </div>
+  );
+};

--- a/app/components/TeamCRUD/TeamCRUDTrigger.jsx
+++ b/app/components/TeamCRUD/TeamCRUDTrigger.jsx
@@ -1,0 +1,24 @@
+import { useOffcanvas } from "tabler-react-2/dist/offcanvas";
+import { TeamCRUD } from "./TeamCRUD";
+import { Button } from "tabler-react-2";
+
+export const TeamCRUDTrigger = ({ children, team, ...props }) => {
+  const { OffcanvasElement, close, offcanvas } = useOffcanvas({
+    offcanvasProps: { position: "end", size: 500, zIndex: 1051 },
+  });
+
+  return (
+    <>
+      {OffcanvasElement}
+      <Button
+        onClick={() =>
+          offcanvas({ content: <TeamCRUD onClose={close} team={team} /> })
+        }
+        {...props}
+      >
+        {children}
+      </Button>
+    </>
+  );
+};
+

--- a/app/components/TeamDeleteTrigger/TeamDeleteTrigger.jsx
+++ b/app/components/TeamDeleteTrigger/TeamDeleteTrigger.jsx
@@ -1,0 +1,19 @@
+import { Button } from "tabler-react-2";
+import { useRegistrationTeam } from "../../hooks/useRegistrationTeam";
+
+export const TeamDeleteTrigger = ({ children, teamId, onDelete, eventId, ...props }) => {
+  const { DeleteConfirmElement: ConfirmModal, deleteTeam } = useRegistrationTeam({
+    eventId,
+    teamId,
+  });
+
+  return (
+    <>
+      {ConfirmModal}
+      <Button onClick={() => deleteTeam(onDelete)} variant="danger" outline {...props}>
+        {children}
+      </Button>
+    </>
+  );
+};
+

--- a/app/hooks/useRegistrationTeam.jsx
+++ b/app/hooks/useRegistrationTeam.jsx
@@ -1,0 +1,113 @@
+import useSWR, { mutate } from "swr";
+import { authFetch } from "../util/url";
+import { useState } from "react";
+import toast from "react-hot-toast";
+import { useConfirm } from "tabler-react-2";
+import { dezerialize } from "zodex";
+
+const fetcher = (url) => authFetch(url).then((r) => r.json());
+const fetchSchema = async ([url]) => {
+  const res = await authFetch(url, {
+    method: "QUERY",
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!res.ok) throw new Error("Failed to fetch schema");
+  const raw = await res.json();
+  return dezerialize(raw);
+};
+
+export const useRegistrationTeam = ({ eventId, teamId }) => {
+  const key = `/api/events/${eventId}/registration/team/${teamId}`;
+  const listKey = `/api/events/${eventId}/registration/team`;
+
+  const { data, error, isLoading } = useSWR(key, fetcher);
+  const { data: schema, loading: schemaLoading } = useSWR(
+    [key, "schema"],
+    fetchSchema
+  );
+  const [mutationLoading, setMutationLoading] = useState(false);
+  const [validationError, setValidationError] = useState(null);
+  const { confirm, ConfirmModal } = useConfirm({
+    title: "Delete this team?",
+    text: "This action cannot be undone.",
+  });
+
+  const updateTeam = async (_data) => {
+    setMutationLoading(true);
+    try {
+      const parsed = schema.safeParse(_data);
+      if (!parsed.success) {
+        toast.error("Error updating team");
+        setValidationError(parsed.error.format());
+        return false;
+      }
+      const promise = authFetch(key, {
+        method: "PUT",
+        body: JSON.stringify(parsed.data),
+      }).then(async (r) => {
+        if (!r.ok) {
+          const j = await r.json().catch(() => ({}));
+          if (r.status === 400 && j?.message) setValidationError(j.message);
+          throw new Error("Request failed");
+        }
+        return r.json();
+      });
+
+      await toast.promise(promise, {
+        loading: "Updating...",
+        success: "Updated successfully",
+        error: "Error",
+      });
+
+      await mutate(key);
+      await mutate(listKey);
+      return true;
+    } catch (e) {
+      return false;
+    } finally {
+      setMutationLoading(false);
+    }
+  };
+
+  const deleteTeam = async (onDelete) => {
+    if (await confirm()) {
+      setMutationLoading(true);
+      try {
+        const promise = authFetch(key, { method: "DELETE" }).then(async (r) => {
+          const j = await r.json();
+          if (!r.ok) throw new Error(j?.message || "Request failed");
+          return j;
+        });
+
+        await toast.promise(promise, {
+          loading: "Deleting...",
+          success: "Deleted successfully",
+          error: (e) => e?.message || "Error deleting",
+        });
+
+        await mutate(key);
+        await mutate(listKey);
+        onDelete?.();
+        return true;
+      } catch (e) {
+        return false;
+      } finally {
+        setMutationLoading(false);
+      }
+    }
+  };
+
+  return {
+    team: data?.team,
+    loading: isLoading,
+    mutationLoading,
+    error,
+    refetch: () => mutate(key),
+    schema,
+    schemaLoading,
+    validationError,
+    updateTeam,
+    deleteTeam,
+    DeleteConfirmElement: ConfirmModal,
+  };
+};

--- a/app/hooks/useRegistrationTeams.jsx
+++ b/app/hooks/useRegistrationTeams.jsx
@@ -1,0 +1,77 @@
+import useSWR, { mutate } from "swr";
+import { authFetch } from "../util/url";
+import { useState } from "react";
+import toast from "react-hot-toast";
+import { dezerialize } from "zodex";
+
+const fetcher = (url) => authFetch(url).then((r) => r.json());
+const fetchSchema = async ([url]) => {
+  const res = await authFetch(url, {
+    method: "QUERY",
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!res.ok) throw new Error("Failed to fetch schema");
+  const raw = await res.json();
+  return dezerialize(raw);
+};
+
+export const useRegistrationTeams = ({ eventId }) => {
+  const key = `/api/events/${eventId}/registration/team`;
+
+  const { data, error, isLoading } = useSWR(key, fetcher);
+  const { data: schema, loading: schemaLoading } = useSWR(
+    [key, "schema"],
+    fetchSchema
+  );
+  const [mutationLoading, setMutationLoading] = useState(false);
+  const [validationError, setValidationError] = useState(null);
+
+  const createTeam = async (_data) => {
+    setMutationLoading(true);
+    try {
+      const parsed = schema.safeParse(_data);
+      if (!parsed.success) {
+        toast.error("Error creating team");
+        setValidationError(parsed.error.format());
+        return false;
+      }
+
+      const promise = authFetch(key, {
+        method: "POST",
+        body: JSON.stringify(parsed.data),
+      }).then(async (r) => {
+        if (!r.ok) {
+          const j = await r.json().catch(() => ({}));
+          if (r.status === 400 && j?.message) setValidationError(j.message);
+          throw new Error("Request failed");
+        }
+        return r.json();
+      });
+
+      await toast.promise(promise, {
+        loading: "Creating...",
+        success: "Created successfully",
+        error: "Error",
+      });
+
+      await mutate(key);
+      return true;
+    } catch (e) {
+      return false;
+    } finally {
+      setMutationLoading(false);
+    }
+  };
+
+  return {
+    teams: data?.teams,
+    loading: isLoading,
+    validationError,
+    mutationLoading,
+    error,
+    refetch: () => mutate(key),
+    schema,
+    schemaLoading,
+    createTeam,
+  };
+};

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -29,6 +29,7 @@ import { RegistrationBuilder } from "./routes/events/[eventId]/registration/buil
 import { FinancialsPage } from "./routes/events/[eventId]/financials";
 import { RegistrationFormBuilderPage } from "./routes/events/[eventId]/registration/forms";
 import { UpsellsPage } from "./routes/events/[eventId]/registration/upsells";
+import { TeamsPage } from "./routes/events/[eventId]/registration/teams";
 import { RegistrationsPage } from "./routes/events/[eventId]/registration/registrations";
 import { SelectedInstanceProvider } from "../contexts/SelectedInstanceContext";
 const useNewConversationPage = true;
@@ -114,6 +115,10 @@ export default () => {
             <Route
               path="/events/:eventId/registration/upsells"
               element={<UpsellsPage />}
+            />
+            <Route
+              path="/events/:eventId/registration/teams"
+              element={<TeamsPage />}
             />
             <Route
               path="/events/:eventId/registration/registrations"

--- a/app/src/routes/events/[eventId]/registration/teams.jsx
+++ b/app/src/routes/events/[eventId]/registration/teams.jsx
@@ -1,0 +1,59 @@
+import { useParams } from "react-router-dom";
+import { EventPage } from "../../../../../components/eventPage/EventPage";
+import { Table } from "tabler-react-2";
+import { Row } from "../../../../../util/Flex";
+import { TeamCRUDTrigger } from "../../../../../components/TeamCRUD/TeamCRUDTrigger";
+import { TeamDeleteTrigger } from "../../../../../components/TeamDeleteTrigger/TeamDeleteTrigger";
+import { useRegistrationTeams } from "../../../../../hooks/useRegistrationTeams";
+
+export const TeamsPage = () => {
+  const { eventId } = useParams();
+  const { teams, loading } = useRegistrationTeams({ eventId });
+
+  return (
+    <EventPage title="Teams" loading={loading}>
+      <TeamCRUDTrigger>Add Team</TeamCRUDTrigger>
+      <div className="mt-3" />
+      <div className="table-responsive">
+        <Table
+          className="card table-responsive"
+          columns={[
+            {
+              label: "Edit",
+              accessor: "id",
+              render: (v, r) => (
+                <Row gap={1} align="center">
+                  <TeamCRUDTrigger size="sm" team={r}>
+                    Edit
+                  </TeamCRUDTrigger>
+                  <TeamDeleteTrigger size="sm" teamId={r.id} eventId={eventId}>
+                    Delete
+                  </TeamDeleteTrigger>
+                </Row>
+              ),
+            },
+            { label: "Name", accessor: "name" },
+            { label: "Code", accessor: "code" },
+            {
+              label: "Max Size",
+              accessor: "maxSize",
+              render: (v) => (v ? v : "Unlimited"),
+            },
+            {
+              label: "Members",
+              accessor: "memberCount",
+            },
+            {
+              label: "Spots Available",
+              accessor: "__avail",
+              render: (_, r) =>
+                r.maxSize ? Math.max(0, r.maxSize - (r.memberCount || 0)) : "Unlimited",
+            },
+          ]}
+          data={teams}
+        />
+      </div>
+    </EventPage>
+  );
+};
+


### PR DESCRIPTION
This pull request introduces a full-featured CRUD (Create, Read, Update, Delete) system for managing event registration teams, including both backend API endpoints and frontend UI components. It adds soft-delete capability to teams, enforces unique codes, supports optional team size limits, and provides a new Teams management page for event managers.

**Backend: Team Management API & Database Changes**

* Added a `deleted` boolean column to the `Team` model and database schema to enable soft-deletion of teams. All API queries now filter out deleted teams. [[1]](diffhunk://#diff-70a4304c81a1a8d650e1bb536bc358bcbce327c8bd333d5782690720896f6acfR1-R2) [[2]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdR865)
* Implemented RESTful endpoints for teams under `api/routes/events/[eventId]/registration/team` and `[teamId]`, supporting create, read, update, and soft-delete, with validation and unique code handling. ([api/routes/events/[eventId]/registration/team/index.jsR1-R106](diffhunk://#diff-38ae58b64b48054aaf4a02ff1850ae29c4b041d3ff963057b5d6c28569b4dab9R1-R106), [api/routes/events/[eventId]/registration/team/[teamId].jsR1-R99](diffhunk://#diff-dbf1351db2d3b565393ce5a2bd67857e69e7c4dc1fde41814048714a721d34d3R1-R99))
* Added a utility function `generateTeamCode` to create unique team codes when not provided.

**Frontend: Team Management UI**

* Created a new Teams management page (`TeamsPage`) accessible at `/events/:eventId/registration/teams`, displaying a table of teams with edit and delete actions. ([app/src/routes/events/[eventId]/registration/teams.jsxR1-R59](diffhunk://#diff-748b656af6f7a6baa2c7af58c1651e45b982219971ad12f63299acf2f3ae9dfcR1-R59), [[1]](diffhunk://#diff-2b0f1b18c06cf8c2dac21734817e2f924e91d740753583b539fdabfe0d0e7ff8R32) [[2]](diffhunk://#diff-2b0f1b18c06cf8c2dac21734817e2f924e91d740753583b539fdabfe0d0e7ff8R119-R122)
* Added reusable components for creating and editing teams (`TeamCRUD`, `TeamCRUDTrigger`) and for confirming team deletion (`TeamDeleteTrigger`). [[1]](diffhunk://#diff-6a54089788c760d1f14359af6070054936b286b1be9ecbc73decbce38f72ed53R1-R118) [[2]](diffhunk://#diff-b4d61f71c4383ea31db8caccbfb7a673f47e91c9234fd9f8a032506b072f299eR1-R24) [[3]](diffhunk://#diff-e48e47f021093b8483fb11a8d1adc9f8bebf506cf40647bb1abd1282a1fe5335R1-R19)
* Implemented React hooks (`useRegistrationTeams`, `useRegistrationTeam`) to interact with the new API endpoints, including schema-based validation, optimistic UI updates, and toast notifications for user feedback. [[1]](diffhunk://#diff-59b54fb8e10352d2c48c139b6e515b76a0b721dbf7f44dd612424e37d7675f97R1-R77) [[2]](diffhunk://#diff-5207f420270e8a3bd19ab4f35cfecacc9d3a06618d133e32bffa950122c7a4b8R1-R113)

These changes together provide event managers with a robust interface for managing teams, ensuring data integrity, and improving the overall user experience.