### PR TITLE
Rename volunteer form references models

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -335,8 +335,8 @@ model Event {
   threads   String?
 
   instances           EventInstance[]
-  formFields          FormField[]
-  formResponses       FormResponse[]
+  formFields          VolunteerRegistrationField[]
+  formResponses       VolunteerRegistration[]
   logs                Logs[]
   crmPersons          CrmPerson[]
   crmFields           CrmField[]
@@ -376,8 +376,8 @@ model EventInstance {
 
   logs                      Logs[]
   LedgerItem                LedgerItem[]
-  FormField                 FormField[]
-  FormResponse              FormResponse[]
+  FormField                 VolunteerRegistrationField[]
+  FormResponse              VolunteerRegistration[]
   Location                  Location[]
   Job                       Job[]
   Shift                     Shift[]
@@ -436,7 +436,7 @@ model CrmPersonsImport {
   updatedAt DateTime @updatedAt
 }
 
-model FormField {
+model VolunteerRegistrationField {
   id           String  @id @default(cuid())
   type         String
   label        String
@@ -450,8 +450,8 @@ model FormField {
   eventpilotFieldType String?
   autocompleteType    String?
 
-  options        FormFieldOption[]
-  fieldResponses FieldResponse[]
+  options        VolunteerRegistrationFieldOption[]
+  fieldResponses VolunteerRegistrationAnswer[]
 
   deleted Boolean @default(false)
 
@@ -465,22 +465,24 @@ model FormField {
   instance   EventInstance @relation(fields: [instanceId], references: [id], onDelete: Cascade)
 
   logs Logs[]
+  @@map("FormField")
 }
 
-model FormFieldOption {
+model VolunteerRegistrationFieldOption {
   id      String    @id @default(cuid())
   fieldId String
-  field   FormField @relation(fields: [fieldId], references: [id], onDelete: Cascade)
+  field   VolunteerRegistrationField @relation(fields: [fieldId], references: [id], onDelete: Cascade)
   label   String
   order   Int
   deleted Boolean   @default(false)
 
   @@index([fieldId])
+  @@map("FormFieldOption")
 }
 
-model FormResponse {
+model VolunteerRegistration {
   id             String          @id @default(cuid())
-  fieldResponses FieldResponse[]
+  fieldResponses VolunteerRegistrationAnswer[]
   pii            PII?
   deleted        Boolean         @default(false)
 
@@ -496,14 +498,15 @@ model FormResponse {
   instance   EventInstance @relation(fields: [instanceId], references: [id], onDelete: Cascade)
 
   logs   Logs[]
-  shifts FormResponseShift[]
+  shifts VolunteerShiftSignup[]
+  @@map("FormResponse")
 }
 
 model PII {
   id String @id @default(cuid())
 
   formResponseId String?       @unique
-  formResponse   FormResponse? @relation(fields: [formResponseId], references: [id], onDelete: Cascade)
+  formResponse   VolunteerRegistration? @relation(fields: [formResponseId], references: [id], onDelete: Cascade)
 
   userAgent    String?
   ipAddress    String?
@@ -520,16 +523,17 @@ model PII {
   updatedAt DateTime @updatedAt
 }
 
-model FieldResponse {
+model VolunteerRegistrationAnswer {
   id         String       @id @default(cuid())
   responseId String
-  response   FormResponse @relation(fields: [responseId], references: [id], onDelete: Cascade)
+  response   VolunteerRegistration @relation(fields: [responseId], references: [id], onDelete: Cascade)
   fieldId    String
-  field      FormField    @relation(fields: [fieldId], references: [id])
+  field      VolunteerRegistrationField    @relation(fields: [fieldId], references: [id])
   value      String?
 
   @@index([responseId])
   @@index([fieldId])
+  @@map("FieldResponse")
 }
 
 model Location {
@@ -597,11 +601,11 @@ enum JobRestrictions {
   OTHER
 }
 
-model FormResponseShift {
+model VolunteerShiftSignup {
   id String @id @default(cuid())
 
   formResponseId String
-  formResponse   FormResponse @relation(fields: [formResponseId], references: [id], onDelete: Cascade)
+  formResponse   VolunteerRegistration @relation(fields: [formResponseId], references: [id], onDelete: Cascade)
 
   shiftId String
   shift   Shift  @relation(fields: [shiftId], references: [id], onDelete: Cascade)
@@ -611,6 +615,7 @@ model FormResponseShift {
 
   // Unique by shiftId and formResponseId
   @@unique([shiftId, formResponseId])
+  @@map("FormResponseShift")
 }
 
 model Shift {
@@ -640,7 +645,7 @@ model Shift {
   open     Boolean @default(true)
   active   Boolean @default(true)
 
-  volunteers FormResponseShift[]
+  volunteers VolunteerShiftSignup[]
 
   logs    Logs[]
   deleted Boolean @default(false)
@@ -680,7 +685,7 @@ model CrmPersonLink {
   crmPerson   CrmPerson @relation(fields: [crmPersonId], references: [id], onDelete: Cascade)
 
   formResponseId String?       @unique
-  formResponse   FormResponse? @relation(fields: [formResponseId], references: [id], onDelete: Cascade)
+  formResponse   VolunteerRegistration? @relation(fields: [formResponseId], references: [id], onDelete: Cascade)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1068,10 +1073,10 @@ model Logs {
   instance   EventInstance? @relation(fields: [instanceId], references: [id], onDelete: Cascade)
 
   formFieldId String?
-  formField   FormField? @relation(fields: [formFieldId], references: [id], onDelete: Cascade)
+  formField   VolunteerRegistrationField? @relation(fields: [formFieldId], references: [id], onDelete: Cascade)
 
   formResponseId String?
-  formResponse   FormResponse? @relation(fields: [formResponseId], references: [id], onDelete: Cascade)
+  formResponse   VolunteerRegistration? @relation(fields: [formResponseId], references: [id], onDelete: Cascade)
 
   locationId String?
   location   Location? @relation(fields: [locationId], references: [id], onDelete: Cascade)

--- a/api/routes/events/[eventId]/dash.js
+++ b/api/routes/events/[eventId]/dash.js
@@ -21,7 +21,7 @@ const eventStart = async (eventId, instanceId) => {
 };
 
 const volunteerRegistrationByDay = async (eventId, instanceId) => {
-  const responses = await prisma.formResponse.findMany({
+  const responses = await prisma.volunteerRegistration.findMany({
     where: { eventId, instanceId, deleted: false },
   });
 
@@ -57,7 +57,7 @@ export const get = [
       const jobCountPromise = prisma.job.count({
         where: { eventId, instanceId, deleted: false },
       });
-      const registrationCountPromise = prisma.formResponse.count({
+      const registrationCountPromise = prisma.volunteerRegistration.count({
         where: { eventId, instanceId, deleted: false },
       });
       const volunteerRegistrationByDayPromise = volunteerRegistrationByDay(

--- a/api/routes/events/[eventId]/search.js
+++ b/api/routes/events/[eventId]/search.js
@@ -43,7 +43,7 @@ export const get = [
           deleted: false,
         },
       }),
-      prisma.formResponse.findMany({
+      prisma.volunteerRegistration.findMany({
         where: { eventId, deleted: false },
         include: {
           fieldResponses: {
@@ -59,7 +59,7 @@ export const get = [
       ...shifts.map((r) => ({ model: "Shift", data: r })),
       ...formResponses
         .filter((r) => r.fieldResponses.length > 0)
-        .map((r) => ({ model: "FormResponse", data: r })),
+        .map((r) => ({ model: "VolunteerRegistration", data: r })),
     ];
 
     return res.json(results);

--- a/api/routes/events/[eventId]/submission/[submissionId]/index.js
+++ b/api/routes/events/[eventId]/submission/[submissionId]/index.js
@@ -60,7 +60,7 @@ export const groupByLocationAndJob = (responses) => {
 };
 
 export const findSubmission = async (eventId, submissionId) => {
-  const fields = await prisma.formField.findMany({
+  const fields = await prisma.volunteerRegistrationField.findMany({
     where: { eventId, deleted: false },
     orderBy: { order: "asc" },
     select: {
@@ -76,7 +76,7 @@ export const findSubmission = async (eventId, submissionId) => {
     },
   });
 
-  const resp = await prisma.formResponse.findUnique({
+  const resp = await prisma.volunteerRegistration.findUnique({
     where: { id: submissionId },
     include: {
       fieldResponses: {
@@ -117,7 +117,7 @@ export const findSubmission = async (eventId, submissionId) => {
     currentlyInForm: !f.deleted,
   }));
 
-  const otherResponsesWithSameFingerprint = await prisma.formResponse.findMany({
+  const otherResponsesWithSameFingerprint = await prisma.volunteerRegistration.findMany({
     where: {
       eventId,
       deleted: false,
@@ -191,13 +191,13 @@ export const put = [
     const { values } = parse.data;
 
     try {
-      const from = await prisma.formResponse.findUnique({
+      const from = await prisma.volunteerRegistration.findUnique({
         where: { id: submissionId },
         include: { fieldResponses: true },
       });
 
       // Overwrite all existing fieldResponses for this submission
-      const updated = await prisma.formResponse.update({
+      const updated = await prisma.volunteerRegistration.update({
         where: { id: submissionId },
         data: {
           fieldResponses: {
@@ -245,7 +245,7 @@ export const patch = [
       }
 
       const incomingShifts = parseResult.data; // array of { id, … }
-      const registeredShifts = await prisma.formResponseShift.findMany({
+      const registeredShifts = await prisma.volunteerShiftSignup.findMany({
         where: { formResponseId: submissionId },
         select: { id: true, shiftId: true },
       });
@@ -268,14 +268,14 @@ export const patch = [
 
       // apply removals
       if (toDelete.length) {
-        await prisma.formResponseShift.deleteMany({
+        await prisma.volunteerShiftSignup.deleteMany({
           where: { id: { in: toDelete } },
         });
       }
 
       // apply additions (skipDuplicates guards against any unique-constraint conflicts)
       if (toCreate.length) {
-        await prisma.formResponseShift.createMany({
+        await prisma.volunteerShiftSignup.createMany({
           data: toCreate,
           skipDuplicates: true,
         });
@@ -301,14 +301,14 @@ export const del = [
     const { submissionId, eventId } = req.params;
     try {
       // Ensure it belongs to this event
-      let resp = await prisma.formResponse.findUnique({
+      let resp = await prisma.volunteerRegistration.findUnique({
         where: { id: submissionId },
       });
       if (!resp || resp.eventId !== eventId) {
         return res.status(404).json({ message: "Submission not found" });
       }
 
-      resp = await prisma.formResponse.update({
+      resp = await prisma.volunteerRegistration.update({
         where: { id: submissionId },
         data: { deleted: true },
       });

--- a/api/routes/events/[eventId]/submission/[submissionId]/index.js
+++ b/api/routes/events/[eventId]/submission/[submissionId]/index.js
@@ -336,10 +336,15 @@ export const formatFormResponse = (resp, fields) => {
     obj[f.id] = null;
   }
   for (const fr of resp.fieldResponses) {
-    const field = fields.find((f) => f.id === fr.fieldId);
+    // Prefer hydrated field on the response, otherwise fall back to provided list
+    const hydratedField = fr.field;
+    const fallbackField = fields.find((f) => f.id === fr.fieldId);
+    const field = hydratedField || fallbackField;
     if (!field) continue;
+
     if (field.type === "dropdown") {
-      const opt = field.options.find((o) => o.id === fr.value);
+      const fieldOptions = hydratedField?.options || fallbackField?.options || [];
+      const opt = fieldOptions.find((o) => o.id === fr.value);
       obj[field.id] = opt ? { id: opt.id, label: opt.label } : null;
     } else {
       obj[field.id] = fr.value;

--- a/api/routes/events/[eventId]/submission/index.js
+++ b/api/routes/events/[eventId]/submission/index.js
@@ -181,7 +181,17 @@ export const get = [
         where: { eventId, deleted: false, instanceId },
         include: {
           fieldResponses: {
-            select: { fieldId: true, value: true },
+            select: {
+              fieldId: true,
+              value: true,
+              field: {
+                select: {
+                  id: true,
+                  type: true,
+                  options: { select: { id: true, label: true, deleted: true } },
+                },
+              },
+            },
           },
         },
       });

--- a/api/routes/events/[eventId]/submission/index.js
+++ b/api/routes/events/[eventId]/submission/index.js
@@ -25,7 +25,7 @@ export const post = async (req, res) => {
   const instanceId = req.instanceId;
 
   try {
-    const formResponse = await prisma.formResponse.create({
+    const formResponse = await prisma.volunteerRegistration.create({
       data: {
         event: { connect: { slug: eventId } },
         instance: { connect: { id: instanceId } },
@@ -46,7 +46,7 @@ export const post = async (req, res) => {
       },
     });
 
-    await prisma.formResponseShift.createMany({
+    await prisma.volunteerShiftSignup.createMany({
       data: shifts.map((s) => ({
         formResponseId: formResponse.id,
         shiftId: s.id,
@@ -165,7 +165,7 @@ export const get = [
     const instanceId = req.instanceId;
 
     try {
-      const fields = await prisma.formField.findMany({
+      const fields = await prisma.volunteerRegistrationField.findMany({
         where: { eventId, instanceId },
         orderBy: { order: "asc" },
         select: {
@@ -177,7 +177,7 @@ export const get = [
         },
       });
 
-      const rawResponses = await prisma.formResponse.findMany({
+      const rawResponses = await prisma.volunteerRegistration.findMany({
         where: { eventId, deleted: false, instanceId },
         include: {
           fieldResponses: {

--- a/api/routes/webhooks/cron.js
+++ b/api/routes/webhooks/cron.js
@@ -15,7 +15,7 @@ export const post = async (req, res) => {
       });
 
       for (const event of events) {
-        const newFormResponses = await prisma.formResponse.count({
+        const newFormResponses = await prisma.volunteerRegistration.count({
           where: {
             createdAt: { gt: new Date(Date.now() - 3600000) },
             eventId: event.id,

--- a/api/scripts/backFillInstanceIds.js
+++ b/api/scripts/backFillInstanceIds.js
@@ -7,7 +7,7 @@ export const backfillInstanceIds = async () => {
 
   // list all the models you made instanceId required on:
   const updates = [
-    prisma.formField.updateMany({
+    prisma.volunteerRegistrationField.updateMany({
       where: { instanceId: null },
       data: { instanceId: defaultInstanceId },
     }),

--- a/api/util/calculateProgress.js
+++ b/api/util/calculateProgress.js
@@ -24,7 +24,7 @@ export const calculateProgress = async (eventId, instanceId) => {
     periodCount,
   ] = await Promise.all([
     // volunteer form fields
-    prisma.formField.count({
+    prisma.volunteerRegistrationField.count({
       where: { eventId, instanceId, deleted: false },
     }),
     // locations

--- a/api/util/cloneInstance/cloneVolunteerFormFields.js
+++ b/api/util/cloneInstance/cloneVolunteerFormFields.js
@@ -5,13 +5,13 @@ export const cloneVolunteerFormFields = async ({
   toInstanceId,
   summary,
 }) => {
-  const fields = await tx.formField.findMany({
+  const fields = await tx.volunteerRegistrationField.findMany({
     where: { instanceId: fromInstanceId, deleted: false },
     include: { options: true },
   });
 
   for (const f of fields) {
-    const newF = await tx.formField.create({
+    const newF = await tx.volunteerRegistrationField.create({
       data: {
         type: f.type,
         label: f.label,
@@ -30,7 +30,7 @@ export const cloneVolunteerFormFields = async ({
     summary.formFields++;
 
     for (const o of f.options) {
-      await tx.formFieldOption.create({
+      await tx.volunteerRegistrationFieldOption.create({
         data: {
           fieldId: newF.id,
           label: o.label,
@@ -41,4 +41,3 @@ export const cloneVolunteerFormFields = async ({
     }
   }
 };
-


### PR DESCRIPTION
This pull request refactors the volunteer registration data model and related API logic to use more descriptive, domain-specific naming. It replaces generic "Form" and "FormResponse" models and references with "VolunteerRegistration" and related models throughout the Prisma schema and API routes. This improves clarity and maintainability, and ensures that volunteer registration data is clearly separated from other potential form types in the system.

**Database schema refactor:**

* Renamed the following Prisma models and their references: `FormField` → `VolunteerRegistrationField`, `FormFieldOption` → `VolunteerRegistrationFieldOption`, `FormResponse` → `VolunteerRegistration`, `FieldResponse` → `VolunteerRegistrationAnswer`, and `FormResponseShift` → `VolunteerShiftSignup`. Added appropriate `@@map` statements to preserve legacy table names. [[1]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdL338-R339) [[2]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdL379-R380) [[3]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdL439-R439) [[4]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdL453-R454) [[5]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdR468-R485) [[6]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdL499-R509) [[7]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdL523-R536) [[8]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdL600-R608) [[9]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdR618) [[10]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdL643-R648) [[11]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdL683-R688) [[12]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdL1071-R1079)

**API route updates:**

* Updated all API routes under `api/routes/events/` to use the new volunteer registration model and field names, including querying, creation, updating, and deletion logic for registration fields, answers, and shift signups. ([api/routes/events/[eventId]/builder.jsL80-R80](diffhunk://#diff-dc54caba050f927128b2d1233158a8f1538e4c08e3bff1152d8e6f84929027ceL80-R80), [api/routes/events/[eventId]/builder.jsL172-R172](diffhunk://#diff-dc54caba050f927128b2d1233158a8f1538e4c08e3bff1152d8e6f84929027ceL172-R172), [api/routes/events/[eventId]/builder.jsL183-R207](diffhunk://#diff-dc54caba050f927128b2d1233158a8f1538e4c08e3bff1152d8e6f84929027ceL183-R207), [api/routes/events/[eventId]/builder.jsL226-R265](diffhunk://#diff-dc54caba050f927128b2d1233158a8f1538e4c08e3bff1152d8e6f84929027ceL226-R265), [api/routes/events/[eventId]/builder.jsL269-R283](diffhunk://#diff-dc54caba050f927128b2d1233158a8f1538e4c08e3bff1152d8e6f84929027ceL269-R283), [api/routes/events/[eventId]/dash.jsL24-R24](diffhunk://#diff-07a6dbd2f5856dcc783a1f6b1982c5f7d0f485f6c79a498c199f2b5e4c9e2a19L24-R24), [api/routes/events/[eventId]/dash.jsL60-R60](diffhunk://#diff-07a6dbd2f5856dcc783a1f6b1982c5f7d0f485f6c79a498c199f2b5e4c9e2a19L60-R60), [api/routes/events/[eventId]/search.jsL46-R46](diffhunk://#diff-23e02e045c167f091b82470095467894ef36be21c31509e11dc8f28e7f9bf3bfL46-R46), [api/routes/events/[eventId]/search.jsL62-R62](diffhunk://#diff-23e02e045c167f091b82470095467894ef36be21c31509e11dc8f28e7f9bf3bfL62-R62), [api/routes/events/[eventId]/submission/[submissionId]/index.jsL63-R63](diffhunk://#diff-3549f27e83fff5e2469ebd8eb7d8182e11c9e493ea5edf028575428cabb9735cL63-R63), [api/routes/events/[eventId]/submission/[submissionId]/index.jsL79-R79](diffhunk://#diff-3549f27e83fff5e2469ebd8eb7d8182e11c9e493ea5edf028575428cabb9735cL79-R79), [api/routes/events/[eventId]/submission/[submissionId]/index.jsL120-R120](diffhunk://#diff-3549f27e83fff5e2469ebd8eb7d8182e11c9e493ea5edf028575428cabb9735cL120-R120), [api/routes/events/[eventId]/submission/[submissionId]/index.jsL194-R200](diffhunk://#diff-3549f27e83fff5e2469ebd8eb7d8182e11c9e493ea5edf028575428cabb9735cL194-R200), [api/routes/events/[eventId]/submission/[submissionId]/index.jsL248-R248](diffhunk://#diff-3549f27e83fff5e2469ebd8eb7d8182e11c9e493ea5edf028575428cabb9735cL248-R248), [api/routes/events/[eventId]/submission/[submissionId]/index.jsL271-R278](diffhunk://#diff-3549f27e83fff5e2469ebd8eb7d8182e11c9e493ea5edf028575428cabb9735cL271-R278), [api/routes/events/[eventId]/submission/[submissionId]/index.jsL304-R311](diffhunk://#diff-3549f27e83fff5e2469ebd8eb7d8182e11c9e493ea5edf028575428cabb9735cL304-R311))

**Behavioral improvements:**

* Improved the logic for creating and updating registration fields and their options, ensuring options are handled correctly even when not present, and that option-level create/update/delete operations are robust. ([api/routes/events/[eventId]/builder.jsL183-R207](diffhunk://#diff-dc54caba050f927128b2d1233158a8f1538e4c08e3bff1152d8e6f84929027ceL183-R207), [api/routes/events/[eventId]/builder.jsL226-R265](diffhunk://#diff-dc54caba050f927128b2d1233158a8f1538e4c08e3bff1152d8e6f84929027ceL226-R265))

These changes improve code clarity, reduce ambiguity, and set the stage for future extensibility around volunteer registration.