### PR TITLE
Add teams to participant registration

### DIFF
--- a/api/prisma/migrations/20250901000000_add_public_to_team/migration.sql
+++ b/api/prisma/migrations/20250901000000_add_public_to_team/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Team" ADD COLUMN     "public" BOOLEAN NOT NULL DEFAULT false;

--- a/api/prisma/migrations/20250901001000_add_team_field_type/migration.sql
+++ b/api/prisma/migrations/20250901001000_add_team_field_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "RegistrationFieldType" ADD VALUE 'TEAM';

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -867,6 +867,7 @@ model Team {
   maxSize       Int?
   registrations Registration[]
 
+  public  Boolean @default(false)
   deleted Boolean @default(false)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1037,6 +1038,7 @@ enum RegistrationFieldType {
   DROPDOWN
   REGISTRATIONTIER
   UPSELLS
+  TEAM
 }
 
 model Logs {

--- a/api/routes/events/[eventId]/registration/index.js
+++ b/api/routes/events/[eventId]/registration/index.js
@@ -18,7 +18,7 @@ export const getOrderedFields = async (eventId) => {
       deleted: false,
       page: { deleted: false },
       type: {
-        notIn: ["UPSELLS", "REGISTRATIONTIER", "RICHTEXT"],
+        notIn: ["UPSELLS", "REGISTRATIONTIER", "RICHTEXT", "TEAM"],
       },
     },
   });

--- a/api/routes/events/[eventId]/registration/team/[teamId].js
+++ b/api/routes/events/[eventId]/registration/team/[teamId].js
@@ -37,7 +37,7 @@ export const put = [
     if (!parse.success) {
       return res.status(400).json({ message: parse.error.format() });
     }
-    const { name, code, maxSize } = parse.data;
+    const { name, code, maxSize, public: isPublic } = parse.data;
 
     const before = await prisma.team.findFirst({
       where: {
@@ -60,6 +60,7 @@ export const put = [
           name,
           code: codeToUse,
           maxSize: maxSize ?? null,
+          public: isPublic ?? false,
         },
       });
       return res.json({ team });

--- a/api/routes/events/[eventId]/registration/team/lookup.js
+++ b/api/routes/events/[eventId]/registration/team/lookup.js
@@ -1,0 +1,24 @@
+import { prisma } from "#prisma";
+
+// Public lookup by code to show team name before submit
+export const get = [
+  async (req, res) => {
+    const { eventId } = req.params;
+    const { code } = req.query;
+    if (!code || typeof code !== "string" || !code.trim()) {
+      return res.status(400).json({ message: "Missing team code" });
+    }
+    const team = await prisma.team.findFirst({
+      where: {
+        code: code.trim(),
+        eventId,
+        instanceId: req.instanceId,
+        deleted: false,
+      },
+      select: { id: true, name: true, public: true },
+    });
+    if (!team) return res.status(404).json({ message: "Team not found" });
+    return res.json({ team });
+  },
+];
+

--- a/api/routes/events/[eventId]/registration/team/lookup.js
+++ b/api/routes/events/[eventId]/registration/team/lookup.js
@@ -15,10 +15,15 @@ export const get = [
         instanceId: req.instanceId,
         deleted: false,
       },
-      select: { id: true, name: true, public: true },
+      select: { id: true, name: true, public: true, maxSize: true },
     });
     if (!team) return res.status(404).json({ message: "Team not found" });
-    return res.json({ team });
+
+    const memberCount = await prisma.registration.count({
+      where: { teamId: team.id, instanceId: req.instanceId, finalized: true },
+    });
+    const available = team.maxSize == null || memberCount < team.maxSize;
+
+    return res.json({ team: { ...team, available } });
   },
 ];
-

--- a/api/util/formSchema.js
+++ b/api/util/formSchema.js
@@ -72,6 +72,14 @@ const upsellsField = z.object({
   type: z.literal("upsells")
 })
 
+const teamField = z.object({
+  ...baseField,
+  type: z.literal("team"),
+  label: z.string().default(""),
+  description: z.string().default(""),
+  required: z.boolean().default(false),
+});
+
 const fieldSchema = z.discriminatedUnion("type", [
   textField,
   emailField,
@@ -80,7 +88,8 @@ const fieldSchema = z.discriminatedUnion("type", [
   checkboxField,
   dropdownField,
   registrationTierField,
-  upsellsField
+  upsellsField,
+  teamField
 ]);
 
 export const formSchema = z.object({

--- a/api/util/router.js
+++ b/api/util/router.js
@@ -68,7 +68,15 @@ function getRoutePathFromFile(filePath, routesDir) {
  */
 async function registerRoutes(app, routesDir) {
   async function traverseDir(dir) {
-    const files = fs.readdirSync(dir);
+    // Ensure static route files (no [param]) are registered before dynamic ones
+    const files = fs
+      .readdirSync(dir)
+      .sort((a, b) => {
+        const aIsDyn = a.includes("[");
+        const bIsDyn = b.includes("[");
+        if (aIsDyn !== bIsDyn) return aIsDyn - bIsDyn; // static first
+        return a.localeCompare(b);
+      });
     for (const file of files) {
       const filePath = path.join(dir, file);
       if (isTestFile(filePath)) {

--- a/app/components/FieldConsumer/FieldConsumer.jsx
+++ b/app/components/FieldConsumer/FieldConsumer.jsx
@@ -5,6 +5,7 @@ import { MarkdownRender } from "../markdown/MarkdownRenderer";
 import { RegistrationTierListing } from "../RegistrationTierListing/RegistrationTierListing";
 import { RegistrationUpsellListing } from "../RegistrationUpsellListing/RegistrationUpsellListing";
 import { ShiftFinder } from "../shiftFinder/ShiftFinder";
+import { RegistrationTeamPicker } from "../RegistrationTeamPicker/RegistrationTeamPicker";
 
 export const FieldConsumer = ({
   field,
@@ -130,6 +131,22 @@ export const FieldConsumer = ({
           eventId={eventId}
           value={value}
           setUpsell={(v) => onInput(v)}
+        />
+      );
+    case "team":
+      return inBuilder ? (
+        <>
+          <label className="form-label">Team</label>
+          <div className="mb-3 p-2 bg-gray-200">
+            A team picker will appear here. Participants can search public
+            teams or join by entering a team code.
+          </div>
+        </>
+      ) : (
+        <RegistrationTeamPicker
+          eventId={eventId}
+          value={value}
+          onChange={onInput}
         />
       );
     case "shiftpicker":

--- a/app/components/FieldConsumer/FieldConsumer.jsx
+++ b/app/components/FieldConsumer/FieldConsumer.jsx
@@ -146,6 +146,8 @@ export const FieldConsumer = ({
         <RegistrationTeamPicker
           eventId={eventId}
           value={value}
+          label={field.label}
+          required={field.required}
           onChange={onInput}
         />
       );

--- a/app/components/FormConsumer.v2/FormConsumer.jsx
+++ b/app/components/FormConsumer.v2/FormConsumer.jsx
@@ -19,6 +19,7 @@ export const FormConsumer = ({
     useState(null);
   const [selectedUpsells, setSelectedUpsells] = useState([]);
   const [selectedShifts, setSelectedShifts] = useState([]);
+  const [selectedTeam, setSelectedTeam] = useState({ id: null, code: "" });
 
   // Scroll to top on page change
   useEffect(() => {
@@ -45,10 +46,13 @@ export const FormConsumer = ({
           return field.required ? selectedRegistrationTier !== null : true;
         } else if (type === "shiftpicker") {
           return field.required ? (selectedShifts?.length ?? 0) > 0 : true;
+        } else if (type === "team") {
+          const hasValidSelection = Boolean(selectedTeam?.id);
+          return field.required ? hasValidSelection : true;
         }
         return validateField(field);
       }),
-    [pages, step, responses, selectedRegistrationTier, selectedShifts]
+    [pages, step, responses, selectedRegistrationTier, selectedShifts, selectedTeam]
   );
 
   const handleInput = (fieldId, value) => {
@@ -61,6 +65,8 @@ export const FormConsumer = ({
       responses,
       selectedRegistrationTier,
       selectedUpsells: selectedUpsells.map((u) => u.value),
+      selectedTeamId: selectedTeam?.id || null,
+      enteredTeamCode: selectedTeam?.code || null,
       selectedShifts,
     };
     onSubmit?.(data);
@@ -95,6 +101,8 @@ export const FormConsumer = ({
             ? selectedUpsells
             : type === "shiftpicker"
             ? selectedShifts
+            : type === "team"
+            ? selectedTeam
             : responses[field.id];
         const onInput =
           type === "registrationtier"
@@ -103,6 +111,8 @@ export const FormConsumer = ({
             ? (v) => setSelectedUpsells(v)
             : type === "shiftpicker"
             ? (v) => setSelectedShifts(v)
+            : type === "team"
+            ? (v) => setSelectedTeam(v)
             : (v) => handleInput(field.id, v);
 
         return (

--- a/app/components/FormConsumer.v2/FormConsumer.jsx
+++ b/app/components/FormConsumer.v2/FormConsumer.jsx
@@ -47,8 +47,9 @@ export const FormConsumer = ({
         } else if (type === "shiftpicker") {
           return field.required ? (selectedShifts?.length ?? 0) > 0 : true;
         } else if (type === "team") {
-          const hasValidSelection = Boolean(selectedTeam?.id);
-          return field.required ? hasValidSelection : true;
+          const hasSelection =
+            Boolean(selectedTeam?.id) || Boolean(selectedTeam?.code?.trim());
+          return field.required ? hasSelection : true;
         }
         return validateField(field);
       }),

--- a/app/components/RegistrationTeamPicker/RegistrationTeamPicker.jsx
+++ b/app/components/RegistrationTeamPicker/RegistrationTeamPicker.jsx
@@ -1,0 +1,136 @@
+import React, { useMemo, useState } from "react";
+import {
+  Input,
+  Typography,
+  Alert,
+  DropdownInput,
+  Button,
+} from "tabler-react-2";
+import { usePublicTeams } from "../../hooks/usePublicTeams";
+import { Row } from "../../util/Flex";
+import toast from "react-hot-toast";
+
+// value shape: { id: string|null, code: string }
+export const RegistrationTeamPicker = ({ eventId, value, onChange }) => {
+  const { teams, loading } = usePublicTeams({ eventId });
+  const [code, setCode] = useState("");
+  const [confirmedTeam, setConfirmedTeam] = useState(null);
+
+  const availablePublicTeams = useMemo(
+    () => (teams || []).filter((t) => t.public && t.available),
+    [teams]
+  );
+
+  const items = useMemo(
+    () =>
+      availablePublicTeams.map((t) => ({
+        id: t.id,
+        value: t.id,
+        label: t.name,
+        disabled: false,
+      })),
+    [availablePublicTeams]
+  );
+
+  const handleSelect = (sel) => {
+    const id = sel?.value ?? sel?.id ?? null;
+    if (!id) return;
+    const team = availablePublicTeams.find((t) => t.id === id);
+    setConfirmedTeam(team || { id, name: "Selected team" });
+    onChange?.({ id, code: "" });
+  };
+
+  const handleLookup = async () => {
+    const entered = (code || value?.code || "").trim();
+    if (!entered) return;
+    try {
+      const res = await fetch(
+        `/api/events/${eventId}/registration/team/lookup?code=${encodeURIComponent(
+          entered
+        )}`,
+        {
+          headers: { "X-Instance": localStorage.getItem("instance") },
+        }
+      );
+      if (!res.ok) throw new Error("not-found");
+      const data = await res.json();
+      setConfirmedTeam(data.team);
+      onChange?.({ id: data.team.id, code: "" });
+    } catch (e) {
+      toast.error("Invalid team code");
+    }
+  };
+
+  if (loading) return <div>Loading...</div>;
+
+  if (confirmedTeam) {
+    return (
+      <Alert variant="secondary" title="Team selected">
+        <Row gap={1} justify="space-between" align="center">
+          <Typography.Text className="mb-0">
+            You will join team: <b>{confirmedTeam.name}</b>
+          </Typography.Text>
+          <Button
+            size="sm"
+            outline
+            onClick={() => {
+              setConfirmedTeam(null);
+              setCode("");
+              onChange?.({ id: null, code: "" });
+            }}
+          >
+            Undo
+          </Button>
+        </Row>
+      </Alert>
+    );
+  }
+
+  return (
+    <div>
+      <label className="form-label required">Team</label>
+      {availablePublicTeams.length > 0 ? (
+        <>
+          <Row gap={2} align="center">
+            <DropdownInput
+              items={items}
+              prompt="Pick a public team"
+              value={value?.id ? { value: value.id } : undefined}
+              onChange={handleSelect}
+              aprops={{
+                style: {
+                  flex: 1,
+                  textAlign: "left",
+                  justifyContent: "space-between",
+                },
+              }}
+              style={{ flex: 1, display: "flex" }}
+            />
+            <Typography.Text className="mb-0">or</Typography.Text>
+            <Row gap={1} align="center" style={{ flex: 1 }}>
+              <Input
+                placeholder="Enter team code"
+                value={code}
+                onChange={setCode}
+                className="mb-0"
+                style={{ flex: 1 }}
+              />
+              <Button onClick={handleLookup}>Join</Button>
+            </Row>
+          </Row>
+        </>
+      ) : (
+        <Row gap={1} align="center">
+          <Input
+            placeholder="Enter team code"
+            value={code}
+            onChange={setCode}
+            className="mb-0"
+            style={{ flex: 1 }}
+          />
+          <Button onClick={handleLookup}>Join</Button>
+        </Row>
+      )}
+    </div>
+  );
+};

--- a/app/components/TeamCRUD/TeamCRUD.jsx
+++ b/app/components/TeamCRUD/TeamCRUD.jsx
@@ -60,6 +60,7 @@ const _TeamCRUD = ({ value, onClose, mutationLoading, validationError, onFinish 
       name: team.name,
       code: team.code,
       maxSize: limitSize ? parseInt(team.maxSize ?? 1, 10) : null,
+      public: Boolean(team.public),
     };
     if (await onFinish(payload)) onClose?.();
   };
@@ -86,6 +87,12 @@ const _TeamCRUD = ({ value, onClose, mutationLoading, validationError, onFinish 
         placeholder="Optional — auto-generated if blank"
         invalid={validationError?.code?._errors?.length > 0}
         invalidText={validationError?.code?._errors?.[0]}
+      />
+
+      <Checkbox
+        label="Public team"
+        value={Boolean(team.public)}
+        onChange={(e) => setTeam({ ...team, public: e })}
       />
 
       <label className="form-label">Team Size</label>

--- a/app/hooks/usePublicTeams.jsx
+++ b/app/hooks/usePublicTeams.jsx
@@ -1,0 +1,16 @@
+import useSWR from "swr";
+import { authFetch } from "../util/url";
+
+const fetcher = (url) => authFetch(url).then((r) => r.json());
+
+export const usePublicTeams = ({ eventId }) => {
+  const key = eventId ? `/api/events/${eventId}/registration/team` : null;
+  const { data, error, isLoading } = useSWR(key, fetcher);
+
+  return {
+    teams: data?.teams,
+    loading: isLoading,
+    error,
+  };
+};
+

--- a/app/hooks/usePublicTeams.jsx
+++ b/app/hooks/usePublicTeams.jsx
@@ -1,7 +1,7 @@
 import useSWR from "swr";
-import { authFetch } from "../util/url";
+import { publicFetch } from "../util/url";
 
-const fetcher = (url) => authFetch(url).then((r) => r.json());
+const fetcher = (url) => publicFetch(url).then((r) => r.json());
 
 export const usePublicTeams = ({ eventId }) => {
   const key = eventId ? `/api/events/${eventId}/registration/team` : null;
@@ -13,4 +13,3 @@ export const usePublicTeams = ({ eventId }) => {
     error,
   };
 };
-

--- a/app/hooks/useTeamCodeLookup.jsx
+++ b/app/hooks/useTeamCodeLookup.jsx
@@ -1,0 +1,61 @@
+import useSWR, { mutate as globalMutate } from "swr";
+import { useCallback, useState } from "react";
+import { publicFetch } from "../util/url";
+
+const fetcher = (url) =>
+  publicFetch(url)
+    .then(async (r) => {
+      if (!r.ok) throw new Error("not-found");
+      return r.json();
+    })
+    .catch((e) => {
+      // Normalize to consistent error
+      throw e;
+    });
+
+const buildKey = (eventId, code) =>
+  eventId && code
+    ? `/api/events/${eventId}/registration/team/lookup?code=${encodeURIComponent(
+        code
+      )}`
+    : null;
+
+export const useTeamCodeLookup = ({ eventId }) => {
+  const [key, setKey] = useState(null);
+
+  const { data, error, isLoading } = useSWR(key, fetcher, {
+    revalidateOnFocus: false,
+    shouldRetryOnError: false,
+  });
+
+  const lookup = useCallback(
+    async (c) => {
+      const trimmed = (c || "").trim();
+      const k = buildKey(eventId, trimmed);
+      if (!k) return null;
+      setKey(k);
+      try {
+        const res = await fetcher(k);
+        await globalMutate(k, res, false);
+        return res;
+      } catch (e) {
+        // populate cache with null to avoid flashing old data
+        await globalMutate(k, null, false);
+        return null;
+      }
+    },
+    [eventId]
+  );
+
+  const reset = useCallback(() => {
+    setKey(null);
+  }, []);
+
+  return {
+    team: data?.team,
+    loading: isLoading,
+    error,
+    lookup,
+    reset,
+  };
+};

--- a/app/src/routes/events/[eventId]/registration/forms.jsx
+++ b/app/src/routes/events/[eventId]/registration/forms.jsx
@@ -3,6 +3,7 @@ import { EventPage } from "../../../../../components/eventPage/EventPage";
 import { FormBuilder } from "../../../../../components/FormBuilder.v2/FormBuilder";
 import { useParticipantRegistrationForm } from "../../../../../hooks/useParticipantRegistrationForm";
 import { useRegistrationUpsells } from "../../../../../hooks/useRegistrationUpsells";
+import { useRegistrationTeams } from "../../../../../hooks/useRegistrationTeams";
 
 export const RegistrationFormBuilderPage = () => {
   const { eventId } = useParams();
@@ -13,6 +14,7 @@ export const RegistrationFormBuilderPage = () => {
   const { upsells, loading: upsellsLoading } = useRegistrationUpsells({
     eventId,
   });
+  const { teams, loading: teamsLoading } = useRegistrationTeams({ eventId });
 
   return (
     <EventPage
@@ -26,6 +28,21 @@ export const RegistrationFormBuilderPage = () => {
         initialValues={pages}
         loading={mutationLoading}
         error={error}
+        customFieldTypes={[
+          teams?.length > 0 && {
+            id: "team",
+            label: "Team",
+            description: "Let participants select or join a team by code.",
+            icon: "users",
+            iconColor: "var(--tblr-indigo)",
+            supports: ["label", "description", "required"],
+            defaults: {
+              label: "Team",
+              required: false,
+              description: "Join a team by searching or entering a code.",
+            },
+          },
+        ].filter(Boolean)}
         requiredFieldTypes={[
           {
             id: "participantName",

--- a/app/src/routes/events/[eventId]/registration/forms.jsx
+++ b/app/src/routes/events/[eventId]/registration/forms.jsx
@@ -35,11 +35,10 @@ export const RegistrationFormBuilderPage = () => {
             description: "Let participants select or join a team by code.",
             icon: "users",
             iconColor: "var(--tblr-indigo)",
-            supports: ["label", "description", "required"],
+            supports: ["label", "required"],
             defaults: {
               label: "Team",
               required: false,
-              description: "Join a team by searching or entering a code.",
             },
           },
         ].filter(Boolean)}

--- a/app/src/routes/events/[eventId]/registration/teams.jsx
+++ b/app/src/routes/events/[eventId]/registration/teams.jsx
@@ -35,6 +35,11 @@ export const TeamsPage = () => {
             { label: "Name", accessor: "name" },
             { label: "Code", accessor: "code" },
             {
+              label: "Public",
+              accessor: "public",
+              render: (v) => (v ? "Yes" : "No"),
+            },
+            {
               label: "Max Size",
               accessor: "maxSize",
               render: (v) => (v ? v : "Unlimited"),
@@ -56,4 +61,3 @@ export const TeamsPage = () => {
     </EventPage>
   );
 };
-

--- a/app/util/url.js
+++ b/app/util/url.js
@@ -15,7 +15,7 @@ export const authFetch = async (url, options, redirect = true) => {
     headers: {
       "Content-Type": "application/json",
       ...options?.headers,
-      Authorization: `Bearer ${token}`,
+      ...(token && token !== "null" ? { Authorization: `Bearer ${token}` } : {}),
       "X-Instance": instance,
     },
   });
@@ -39,7 +39,7 @@ export const authFetchWithoutContentType = async (url, options) => {
     ...options,
     headers: {
       ...options?.headers,
-      Authorization: `Bearer ${token}`,
+      ...(token && token !== "null" ? { Authorization: `Bearer ${token}` } : {}),
     },
   });
   if (res.status === 401) {
@@ -47,5 +47,19 @@ export const authFetchWithoutContentType = async (url, options) => {
     window.logout && window.logout();
     emitter.emit("logout");
   }
+  return res;
+};
+
+// For unauthenticated/public endpoints: never attach Authorization header
+export const publicFetch = async (url, options) => {
+  const instance = localStorage.getItem("instance");
+  const res = await fetch(u(url), {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+      "X-Instance": instance,
+    },
+  });
   return res;
 };


### PR DESCRIPTION
This pull request introduces a new "Team" field type for event registration, allowing participants to join public teams or enter a team code to join any team. It adds support for public/private teams, enforces team capacity, and exposes new API endpoints and frontend components for team selection. The changes span database schema updates, backend logic, and frontend integration.

**Database and Schema Changes**
* Added a `public` boolean column to the `Team` model to distinguish between public and private teams, with a default of `false`. [[1]](diffhunk://#diff-ad1bf6f75c057ac3f25c5824c0d52a1994e9998527776b6eb90f7e2de1232628R1-R2) [[2]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdR870)
* Extended the `RegistrationFieldType` enum to include a new value `'TEAM'`, enabling the use of team fields in registration forms. [[1]](diffhunk://#diff-1c1d7d52ded8e3b7439891d944b844baa0cc14c84359d516d3e29757d2addd4aR1-R2) [[2]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdR1041)

**Backend Logic and API Enhancements**
* Updated registration submission logic to allow participants to select a public team or enter a team code; enforces that only public teams are selectable by ID, and any team can be joined by code if not full. ([api/routes/events/[eventId]/registration/consumer.jsR14-R15](diffhunk://#diff-43047fd83f931800128391d3bf8c3d86803127f3028c355a54257662bba5e3e7R14-R15), [api/routes/events/[eventId]/registration/consumer.jsL94-R102](diffhunk://#diff-43047fd83f931800128391d3bf8c3d86803127f3028c355a54257662bba5e3e7L94-R102), [api/routes/events/[eventId]/registration/consumer.jsL163-R212](diffhunk://#diff-43047fd83f931800128391d3bf8c3d86803127f3028c355a54257662bba5e3e7L163-R212))
* Added a new public API endpoint `registration/team/lookup.js` for looking up teams by code, returning team info and availability. ([api/routes/events/[eventId]/registration/team/lookup.jsR1-R29](diffhunk://#diff-38e198f4d154fb46db1c24dd0c9965502ebee0dcacb7c79ed03f1951c8c055daR1-R29))
* Enhanced team creation and update endpoints to support the `public` flag, and adjusted team listing to expose only public teams (with limited fields) to non-managers. ([api/routes/events/[eventId]/registration/team/index.jsR12](diffhunk://#diff-38ae58b64b48054aaf4a02ff1850ae29c4b041d3ff963057b5d6c28569b4dab9R12), [api/routes/events/[eventId]/registration/team/index.jsL23-R24](diffhunk://#diff-38ae58b64b48054aaf4a02ff1850ae29c4b041d3ff963057b5d6c28569b4dab9L23-R24), [api/routes/events/[eventId]/registration/team/index.jsR40](diffhunk://#diff-38ae58b64b48054aaf4a02ff1850ae29c4b041d3ff963057b5d6c28569b4dab9R40), [api/routes/events/[eventId]/registration/team/[teamId].jsL40-R40](diffhunk://#diff-dbf1351db2d3b565393ce5a2bd67857e69e7c4dc1fde41814048714a721d34d3L40-R40), [api/routes/events/[eventId]/registration/team/[teamId].jsR63](diffhunk://#diff-dbf1351db2d3b565393ce5a2bd67857e69e7c4dc1fde41814048714a721d34d3R63), [api/routes/events/[eventId]/registration/team/index.jsL86-R92](diffhunk://#diff-38ae58b64b48054aaf4a02ff1850ae29c4b041d3ff963057b5d6c28569b4dab9L86-R92), [api/routes/events/[eventId]/registration/team/index.jsL100-R123](diffhunk://#diff-38ae58b64b48054aaf4a02ff1850ae29c4b041d3ff963057b5d6c28569b4dab9L100-R123))
* Excluded the new "TEAM" field type from certain backend field queries to maintain correct form logic. ([api/routes/events/[eventId]/registration/index.jsL21-R21](diffhunk://#diff-6fc5cb576ce1fe839504750758c7d695fc5368788e04f3dcb227110727035a08L21-R21))
* Improved route registration to ensure static routes are registered before dynamic ones.

**Frontend Integration**
* Added the `team` field type to the form schema and implemented a `RegistrationTeamPicker` component for user selection of teams during registration. [[1]](diffhunk://#diff-f08653754ffda91e6584c5e4fee798c333f3741365b582431f3edafacf3fd774R75-R82) [[2]](diffhunk://#diff-f08653754ffda91e6584c5e4fee798c333f3741365b582431f3edafacf3fd774L83-R92) [[3]](diffhunk://#diff-fe02f60bb083869000408925b7ca8ac2c198453936d9542d5e2f6a9506c71f4cR8) [[4]](diffhunk://#diff-fe02f60bb083869000408925b7ca8ac2c198453936d9542d5e2f6a9506c71f4cR136-R153)
* Updated the main registration form logic to track and validate team selection, and to submit the selected team or entered code as part of registration data. [[1]](diffhunk://#diff-e0654cb10b3841d6760e041f2fa95c7c7b3d1da956c5ff18aef3e81f46db6ca1R22) [[2]](diffhunk://#diff-e0654cb10b3841d6760e041f2fa95c7c7b3d1da956c5ff18aef3e81f46db6ca1R49-R56) [[3]](diffhunk://#diff-e0654cb10b3841d6760e041f2fa95c7c7b3d1da956c5ff18aef3e81f46db6ca1R69-R70) [[4]](diffhunk://#diff-e0654cb10b3841d6760e041f2fa95c7c7b3d1da956c5ff18aef3e81f46db6ca1R105-R106) [[5]](diffhunk://#diff-e0654cb10b3841d6760e041f2fa95c7c7b3d1da956c5ff18aef3e81f46db6ca1R115-R116)