### PR TITLE
Time data frame enhancements

### DIFF
--- a/api/routes/events/[eventId]/dash/participants.js
+++ b/api/routes/events/[eventId]/dash/participants.js
@@ -8,6 +8,23 @@ export const get = [
     const instanceId = req.instanceId;
 
     try {
+      // Resolve current and previous instances for comparison overlay
+      const currentInstance = await prisma.eventInstance.findUnique({
+        where: { id: instanceId, eventId },
+      });
+
+      let previousInstance = null;
+      if (currentInstance) {
+        previousInstance = await prisma.eventInstance.findFirst({
+          where: {
+            eventId,
+            deleted: false,
+            startTime: { lt: currentInstance.startTime },
+          },
+          orderBy: { startTime: "desc" },
+        });
+      }
+
       // Count finalized participant registrations
       const participantRegistrations = await prisma.registration.count({
         where: { eventId, instanceId, deleted: false, finalized: true },
@@ -33,9 +50,44 @@ export const get = [
         count: Number(r.count),
       }));
 
+      // If a previous instance exists, compute comparable buckets for it
+      let previousRegistrationsByDay = null;
+      if (previousInstance) {
+        const prevRows = await prisma.$queryRaw`
+          SELECT
+            (date_trunc('day', "createdAt" AT TIME ZONE 'America/Chicago'))::date AS day,
+            COUNT(*)::int AS count
+          FROM "Registration"
+          WHERE "eventId" = ${eventId}
+            AND "instanceId" = ${previousInstance.id}
+            AND "deleted" = false
+            AND "finalized" = true
+          GROUP BY 1
+          ORDER BY 1
+        `;
+
+        previousRegistrationsByDay = prevRows.map((r) => ({
+          date: new Date(r.day),
+          count: Number(r.count),
+        }));
+      }
+
       res.json({
         participantRegistrations,
         registrationsByDay,
+        previous: previousInstance
+          ? {
+              instance: {
+                id: previousInstance.id,
+                name: previousInstance.name,
+                startTime: previousInstance.startTime,
+                startTimeTz: previousInstance.startTimeTz,
+                endTime: previousInstance.endTime,
+                endTimeTz: previousInstance.endTimeTz,
+              },
+              registrationsByDay: previousRegistrationsByDay,
+            }
+          : null,
       });
     } catch (error) {
       console.error("Error in GET /events/:eventId/dash/participants:", error);
@@ -43,4 +95,3 @@ export const get = [
     }
   },
 ];
-

--- a/api/routes/events/[eventId]/dash/volunteers.js
+++ b/api/routes/events/[eventId]/dash/volunteers.js
@@ -100,7 +100,8 @@ export const get = [
 
         const previousAsOf = Number(prevAsOfRows?.[0]?.count ?? 0);
         const delta = Number(volunteerRegistrations) - previousAsOf;
-        const percentChange = previousAsOf > 0 ? (delta / previousAsOf) * 100 : null;
+        const percentChange =
+          previousAsOf > 0 ? (delta / previousAsOf) * 100 : null;
         trend = {
           previousAsOf,
           delta,

--- a/api/routes/events/[eventId]/dash/volunteers.js
+++ b/api/routes/events/[eventId]/dash/volunteers.js
@@ -69,9 +69,49 @@ export const get = [
         }));
       }
 
+      // Compute trend against previous instance at the same relative day offset from start
+      // Example: If today is N days from current start, compare current total vs
+      // previous total as-of (previous start + N days), clamped to previous end.
+      let trend = null;
+      if (previousInstance) {
+        const prevEnd = previousInstance.endTime ?? null;
+        const prevAsOfRows = await prisma.$queryRaw`
+          WITH params AS (
+            SELECT
+              date_trunc('day', timezone('America/Chicago', now())) AS today_ct,
+              date_trunc('day', timezone('America/Chicago', ${currentInstance.startTime})) AS cur_start_ct,
+              date_trunc('day', timezone('America/Chicago', ${previousInstance.startTime})) AS prev_start_ct,
+              date_trunc('day', timezone('America/Chicago', ${prevEnd})) AS prev_end_ct
+          ), cutoff AS (
+            SELECT
+              CASE
+                WHEN prev_end_ct IS NULL THEN prev_start_ct + (today_ct - cur_start_ct)
+                ELSE LEAST(prev_start_ct + (today_ct - cur_start_ct), prev_end_ct)
+              END AS prev_cutoff
+            FROM params
+          )
+          SELECT COUNT(*)::int AS count
+          FROM "FormResponse", cutoff
+          WHERE "eventId" = ${eventId}
+            AND "instanceId" = ${previousInstance.id}
+            AND "deleted" = false
+            AND date_trunc('day', timezone('America/Chicago', "createdAt")) <= (SELECT prev_cutoff FROM cutoff)
+        `;
+
+        const previousAsOf = Number(prevAsOfRows?.[0]?.count ?? 0);
+        const delta = Number(volunteerRegistrations) - previousAsOf;
+        const percentChange = previousAsOf > 0 ? (delta / previousAsOf) * 100 : null;
+        trend = {
+          previousAsOf,
+          delta,
+          percentChange,
+        };
+      }
+
       res.json({
         volunteerRegistrations,
         registrationsByDay,
+        trend,
         previous: previousInstance
           ? {
               instance: {

--- a/api/routes/events/[eventId]/dash/volunteers.js
+++ b/api/routes/events/[eventId]/dash/volunteers.js
@@ -8,6 +8,23 @@ export const get = [
     const instanceId = req.instanceId;
 
     try {
+      // Resolve current and previous instances for comparison overlay
+      const currentInstance = await prisma.eventInstance.findUnique({
+        where: { id: instanceId, eventId },
+      });
+
+      let previousInstance = null;
+      if (currentInstance) {
+        previousInstance = await prisma.eventInstance.findFirst({
+          where: {
+            eventId,
+            deleted: false,
+            startTime: { lt: currentInstance.startTime },
+          },
+          orderBy: { startTime: "desc" },
+        });
+      }
+
       const volunteerRegistrations = await prisma.volunteerRegistration.count({
         where: { eventId, instanceId, deleted: false },
       });
@@ -31,9 +48,43 @@ export const get = [
         count: Number(r.count),
       }));
 
+      // If a previous instance exists, compute comparable buckets for it
+      let previousRegistrationsByDay = null;
+      if (previousInstance) {
+        const prevRows = await prisma.$queryRaw`
+          SELECT
+            (date_trunc('day', "createdAt" AT TIME ZONE 'America/Chicago'))::date AS day,
+            COUNT(*)::int AS count
+          FROM "FormResponse"
+          WHERE "eventId" = ${eventId}
+            AND "instanceId" = ${previousInstance.id}
+            AND "deleted" = false
+          GROUP BY 1
+          ORDER BY 1
+        `;
+
+        previousRegistrationsByDay = prevRows.map((r) => ({
+          date: new Date(r.day),
+          count: Number(r.count),
+        }));
+      }
+
       res.json({
         volunteerRegistrations,
         registrationsByDay,
+        previous: previousInstance
+          ? {
+              instance: {
+                id: previousInstance.id,
+                name: previousInstance.name,
+                startTime: previousInstance.startTime,
+                startTimeTz: previousInstance.startTimeTz,
+                endTime: previousInstance.endTime,
+                endTimeTz: previousInstance.endTimeTz,
+              },
+              registrationsByDay: previousRegistrationsByDay,
+            }
+          : null,
       });
     } catch (error) {
       console.error("Error in GET /event/:eventId/registrations:", error);

--- a/app/components/ParticipantRegistrationStatsCard/ParticipantRegistrationStatsCard.jsx
+++ b/app/components/ParticipantRegistrationStatsCard/ParticipantRegistrationStatsCard.jsx
@@ -1,12 +1,30 @@
 import { useParams } from "react-router-dom";
 import { useDashParticipants } from "../../hooks/useDashParticipants";
 import { TimeDataFrame } from "../TimeDataFrame/TimeDataFrame";
+import { useSelectedInstance } from "../../contexts/SelectedInstanceContext";
+import moment from "moment";
+import { buildDate } from "../tzDateTime/tzDateTime";
 
 export const ParticipantRegistrationStatsCard = () => {
   const { eventId } = useParams();
   const { participantRegistrations, registrationsByDay } = useDashParticipants({
     eventId,
   });
+  const { instance } = useSelectedInstance();
+
+  // Build inclusive day range highlight from instance start/end
+  const start = buildDate(instance?.startTime, instance?.startTimeTz);
+  const end = buildDate(instance?.endTime, instance?.endTimeTz);
+  const highlightCells = (() => {
+    if (!start || !end) return [];
+    const s = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate()));
+    const e = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate()));
+    const out = [];
+    for (let d = new Date(s); d <= e; d = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1))) {
+      out.push({ date: new Date(d), color: "rgba(var(--tblr-warning-rgb), 0.25)" });
+    }
+    return out;
+  })();
 
   return (
     <TimeDataFrame
@@ -16,7 +34,13 @@ export const ParticipantRegistrationStatsCard = () => {
       series={registrationsByDay?.map((d) => ({ date: d.date, count: d.count }))}
       unitSingular="Participant"
       unitPlural="Participants"
+      startDate={moment(buildDate(instance?.startTime, instance?.startTimeTz))
+        .subtract(5, "months")
+        .toDate()}
+      endDate={moment(buildDate(instance?.endTime, instance?.endTimeTz))
+        .add(1, "months")
+        .toDate()}
+      HighlightCells={highlightCells}
     />
   );
 };
-

--- a/app/components/ParticipantRegistrationStatsCard/ParticipantRegistrationStatsCard.jsx
+++ b/app/components/ParticipantRegistrationStatsCard/ParticipantRegistrationStatsCard.jsx
@@ -7,7 +7,7 @@ import { buildDate } from "../tzDateTime/tzDateTime";
 
 export const ParticipantRegistrationStatsCard = () => {
   const { eventId } = useParams();
-  const { participantRegistrations, registrationsByDay, previous } = useDashParticipants({
+  const { participantRegistrations, registrationsByDay, previous, loading } = useDashParticipants({
     eventId,
   });
   const { instance } = useSelectedInstance();
@@ -41,6 +41,11 @@ export const ParticipantRegistrationStatsCard = () => {
       title="Participant Registrations"
       totalTitle="Total Participants"
       total={participantRegistrations}
+      loading={loading}
+      loadingTitle="Loading participant stats"
+      loadingText="Crunching registration activity and totals..."
+      emptyTitle="No participant registrations yet"
+      emptyText="Once participants start registering, their daily activity will appear here."
       series={registrationsByDay?.map((d) => ({
         date: d.date,
         count: d.count,

--- a/app/components/ParticipantRegistrationStatsCard/ParticipantRegistrationStatsCard.jsx
+++ b/app/components/ParticipantRegistrationStatsCard/ParticipantRegistrationStatsCard.jsx
@@ -17,11 +17,21 @@ export const ParticipantRegistrationStatsCard = () => {
   const end = buildDate(instance?.endTime, instance?.endTimeTz);
   const highlightCells = (() => {
     if (!start || !end) return [];
-    const s = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate()));
-    const e = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate()));
+    const s = new Date(
+      Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate())
+    );
+    const e = new Date(
+      Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate())
+    );
     const out = [];
-    for (let d = new Date(s); d <= e; d = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1))) {
-      out.push({ date: new Date(d), color: "rgba(var(--tblr-warning-rgb), 0.25)" });
+    for (
+      let d = new Date(s);
+      d <= e;
+      d = new Date(
+        Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1)
+      )
+    ) {
+      out.push({ date: new Date(d), color: "var(--tblr-success)" });
     }
     return out;
   })();
@@ -31,7 +41,10 @@ export const ParticipantRegistrationStatsCard = () => {
       title="Participant Registrations"
       totalTitle="Total Participants"
       total={participantRegistrations}
-      series={registrationsByDay?.map((d) => ({ date: d.date, count: d.count }))}
+      series={registrationsByDay?.map((d) => ({
+        date: d.date,
+        count: d.count,
+      }))}
       unitSingular="Participant"
       unitPlural="Participants"
       startDate={moment(buildDate(instance?.startTime, instance?.startTimeTz))

--- a/app/components/ParticipantRegistrationStatsCard/ParticipantRegistrationStatsCard.jsx
+++ b/app/components/ParticipantRegistrationStatsCard/ParticipantRegistrationStatsCard.jsx
@@ -7,7 +7,7 @@ import { buildDate } from "../tzDateTime/tzDateTime";
 
 export const ParticipantRegistrationStatsCard = () => {
   const { eventId } = useParams();
-  const { participantRegistrations, registrationsByDay } = useDashParticipants({
+  const { participantRegistrations, registrationsByDay, previous } = useDashParticipants({
     eventId,
   });
   const { instance } = useSelectedInstance();
@@ -45,8 +45,18 @@ export const ParticipantRegistrationStatsCard = () => {
         date: d.date,
         count: d.count,
       }))}
+      compareSeries={previous?.registrationsByDay?.map((d) => ({
+        date: d.date,
+        count: d.count,
+      }))}
       unitSingular="Participant"
       unitPlural="Participants"
+      anchorStartDate={buildDate(instance?.startTime, instance?.startTimeTz)}
+      compareStartDate={
+        previous?.instance
+          ? buildDate(previous.instance.startTime, previous.instance.startTimeTz)
+          : undefined
+      }
       startDate={moment(buildDate(instance?.startTime, instance?.startTimeTz))
         .subtract(5, "months")
         .toDate()}

--- a/app/components/TimeDataFrame/TimeDataFrame.jsx
+++ b/app/components/TimeDataFrame/TimeDataFrame.jsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import moment from "moment";
 import { CalendarPlot } from "../plots/calendar";
 import { TimeLineChart } from "../plots/timeline";
-import { Responsive } from "../../util/Flex";
+import { Col, Responsive } from "../../util/Flex";
 import { DataBox } from "../dataBox/DataBox";
 import { Icon } from "../../util/Icon";
 
@@ -153,6 +153,48 @@ export const TimeDataFrame = ({
                   />
                   <span style={{ fontSize: 12 }}>Event dates</span>
                 </div>
+              </div>
+            )}
+            {displayFormat?.id === "timeline" && (
+              <div
+                aria-label="Timeline reference"
+                style={{
+                  display: "flex",
+                  justifyContent: "flex-end",
+                  alignItems: "center",
+                  gap: 16,
+                }}
+              >
+                <Col gap={0} align="flex-start">
+                  <div
+                    style={{ display: "flex", alignItems: "center", gap: 6 }}
+                  >
+                    <div
+                      title="Current instance"
+                      style={{
+                        width: 24,
+                        height: 0,
+                        borderTop: "2px solid var(--tblr-primary)",
+                      }}
+                    />
+                    <span style={{ fontSize: 12 }}>Current</span>
+                  </div>
+                  {!!compareSeries?.length && (
+                    <div
+                      style={{ display: "flex", alignItems: "center", gap: 6 }}
+                    >
+                      <div
+                        title="Previous instance"
+                        style={{
+                          width: 24,
+                          height: 0,
+                          borderTop: "1px dashed var(--tblr-secondary)",
+                        }}
+                      />
+                      <span style={{ fontSize: 12 }}>Previous</span>
+                    </div>
+                  )}
+                </Col>
               </div>
             )}
           </div>

--- a/app/components/TimeDataFrame/TimeDataFrame.jsx
+++ b/app/components/TimeDataFrame/TimeDataFrame.jsx
@@ -124,6 +124,8 @@ export const TimeDataFrame = ({
             height={150}
             unitSingular={unitSingular}
             unitPlural={unitPlural}
+            startDate={startDate}
+            endDate={endDate}
           />
         )}
       </Responsive>

--- a/app/components/TimeDataFrame/TimeDataFrame.jsx
+++ b/app/components/TimeDataFrame/TimeDataFrame.jsx
@@ -27,6 +27,7 @@ export const TimeDataFrame = ({
 
   const calendarData = series?.map((d) => ({ date: d.date, value: d.count }));
   const timelineData = series?.map((d) => ({ date: d.date, qty: d.count }));
+  const maxValue = Math.max(0, ...(series || []).map((d) => d?.count ?? 0));
 
   return (
     <Card title={title}>
@@ -58,17 +59,65 @@ export const TimeDataFrame = ({
           </div>
         </Responsive>
         {displayFormat?.id === "calendar" ? (
-          <CalendarPlot
-            data={calendarData}
-            startDate={startDate}
-            endDate={endDate}
-            highlightToday
-            todayStroke="var(--tblr-danger)"
-            todayStrokeWidth={2}
-            showCounts
-            // Pass through to calendar as lower-cased prop
-            highlightCells={HighlightCells}
-          />
+          <div
+            style={{ display: "flex", flexDirection: "column", width: "100%" }}
+          >
+            {/* Legend / reference aligned top-right, no borders/background */}
+            <div
+              aria-label="Calendar reference"
+              style={{
+                display: "flex",
+                justifyContent: "flex-end",
+                alignItems: "center",
+                gap: 16,
+                marginBottom: 8,
+                width: "100%",
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                <span style={{ fontSize: 12 }}>0</span>
+                <div
+                  title={`Scale: 0 to ${maxValue}`}
+                  style={{
+                    width: 72,
+                    height: 12,
+                    background: "linear-gradient(to right, white, #066fd1)",
+                  }}
+                />
+                <span style={{ fontSize: 12 }}>{maxValue}</span>
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                <div
+                  title="Event dates"
+                  style={{
+                    width: 12,
+                    height: 12,
+                    background: "var(--tblr-success)",
+                  }}
+                />
+                <span style={{ fontSize: 12 }}>Event dates</span>
+              </div>
+            </div>
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "flex-end",
+                width: "100%",
+              }}
+            >
+              <CalendarPlot
+                data={calendarData}
+                startDate={startDate}
+                endDate={endDate}
+                highlightToday
+                todayStroke="var(--tblr-danger)"
+                todayStrokeWidth={2}
+                showCounts
+                // Pass through to calendar as lower-cased prop
+                highlightCells={HighlightCells}
+              />
+            </div>
+          </div>
         ) : (
           <TimeLineChart
             data={timelineData}

--- a/app/components/TimeDataFrame/TimeDataFrame.jsx
+++ b/app/components/TimeDataFrame/TimeDataFrame.jsx
@@ -23,6 +23,10 @@ export const TimeDataFrame = ({
   unitPlural = "Items",
   // Optional: [{ date: Date|string, color: string }]
   HighlightCells = [],
+  // Optional comparison inputs for timeline overlay
+  compareSeries = [], // [{ date, count }]
+  anchorStartDate, // current instance start Date
+  compareStartDate, // previous instance start Date
 }) => {
   const [displayFormat, setDisplayFormat] = useState({ id: defaultDisplay });
   // Timeframe state (in months) and paging by timeframe-size
@@ -40,6 +44,10 @@ export const TimeDataFrame = ({
 
   const calendarData = series?.map((d) => ({ date: d.date, value: d.count }));
   const timelineData = series?.map((d) => ({ date: d.date, qty: d.count }));
+  const compareTimelineData = compareSeries?.map((d) => ({
+    date: d.date,
+    qty: d.count,
+  }));
   const maxValue = Math.max(0, ...(series || []).map((d) => d?.count ?? 0));
 
   return (
@@ -193,6 +201,9 @@ export const TimeDataFrame = ({
                   unitPlural={unitPlural}
                   startDate={viewStartDate}
                   endDate={viewEndDate}
+                  compareData={compareTimelineData}
+                  anchorStartDate={anchorStartDate}
+                  compareStartDate={compareStartDate}
                 />
               </div>
             )}

--- a/app/components/TimeDataFrame/TimeDataFrame.jsx
+++ b/app/components/TimeDataFrame/TimeDataFrame.jsx
@@ -15,6 +15,7 @@ export const TimeDataFrame = ({
   title,
   totalTitle,
   total,
+  trend = null,
   series = [], // [{ date: Date|string, count: number }]
   defaultDisplay = "calendar",
   startDate, // optional; if provided, not used as anchor (endDate is)
@@ -124,7 +125,7 @@ export const TimeDataFrame = ({
           defaultDirection="column"
           colGap={2}
         >
-          <DataBox title={totalTitle} value={total} breakpoint={1000} />
+          <DataBox title={totalTitle} value={total} trend={trend} breakpoint={1000} />
           <div>
             <label className="form-label">Display Format</label>
             <SegmentedControl

--- a/app/components/TimeDataFrame/TimeDataFrame.jsx
+++ b/app/components/TimeDataFrame/TimeDataFrame.jsx
@@ -6,6 +6,8 @@ import { TimeLineChart } from "../plots/timeline";
 import { Col, Responsive } from "../../util/Flex";
 import { DataBox } from "../dataBox/DataBox";
 import { Icon } from "../../util/Icon";
+import { Loading } from "../loading/Loading";
+import { Empty } from "../empty/Empty";
 
 /**
  * TimeDataFrame: A reusable card that shows a total count and
@@ -16,6 +18,9 @@ export const TimeDataFrame = ({
   totalTitle,
   total,
   trend = null,
+  loading = false,
+  loadingTitle = "Loading",
+  loadingText = "We are gathering your data...",
   series = [], // [{ date: Date|string, count: number }]
   defaultDisplay = "calendar",
   startDate, // optional; if provided, not used as anchor (endDate is)
@@ -32,6 +37,9 @@ export const TimeDataFrame = ({
   enableCalendarChangeToggle = false,
   // Fraction of the timeframe to move on prev/next; 0.3 = 30%
   navStepFraction = 0.3,
+  // Empty state customization
+  emptyTitle = "Nothing to show yet",
+  emptyText = "There isn't any data in this timeframe.",
 }) => {
   const [displayFormat, setDisplayFormat] = useState({ id: defaultDisplay });
   const [calendarMetric, setCalendarMetric] = useState({ id: "count" }); // "count" | "change"
@@ -109,8 +117,15 @@ export const TimeDataFrame = ({
     ...changeCalendarData.map((d) => Math.abs(d.value ?? 0))
   );
 
+  const isEmpty = !loading && (!Array.isArray(series) || series.length === 0);
+
   return (
     <Card title={title}>
+      {loading ? (
+        <Loading title={loadingTitle} text={loadingText} gradient={false} />
+      ) : isEmpty ? (
+        <Empty title={emptyTitle} text={emptyText} gradient={false} />
+      ) : (
       <Responsive
         align="center"
         colAlign="flex-start"
@@ -414,6 +429,7 @@ export const TimeDataFrame = ({
           </div>
         </div>
       </Responsive>
+      )}
     </Card>
   );
 };

--- a/app/components/TimeDataFrame/TimeDataFrame.jsx
+++ b/app/components/TimeDataFrame/TimeDataFrame.jsx
@@ -20,6 +20,8 @@ export const TimeDataFrame = ({
   endDate = moment().subtract(5, "months").toDate(),
   unitSingular = "Item",
   unitPlural = "Items",
+  // Optional: [{ date: Date|string, color: string }]
+  HighlightCells = [],
 }) => {
   const [displayFormat, setDisplayFormat] = useState({ id: defaultDisplay });
 
@@ -64,6 +66,8 @@ export const TimeDataFrame = ({
             todayStroke="var(--tblr-danger)"
             todayStrokeWidth={2}
             showCounts
+            // Pass through to calendar as lower-cased prop
+            highlightCells={HighlightCells}
           />
         ) : (
           <TimeLineChart
@@ -77,4 +81,3 @@ export const TimeDataFrame = ({
     </Card>
   );
 };
-

--- a/app/components/TimeDataFrame/TimeDataFrame.jsx
+++ b/app/components/TimeDataFrame/TimeDataFrame.jsx
@@ -1,10 +1,11 @@
-import { Card, SegmentedControl } from "tabler-react-2";
+import { Card, SegmentedControl, Button } from "tabler-react-2";
 import { useState } from "react";
 import moment from "moment";
 import { CalendarPlot } from "../plots/calendar";
 import { TimeLineChart } from "../plots/timeline";
 import { Responsive } from "../../util/Flex";
 import { DataBox } from "../dataBox/DataBox";
+import { Icon } from "../../util/Icon";
 
 /**
  * TimeDataFrame: A reusable card that shows a total count and
@@ -16,14 +17,26 @@ export const TimeDataFrame = ({
   total,
   series = [], // [{ date: Date|string, count: number }]
   defaultDisplay = "calendar",
-  startDate = moment().add(1, "month").toDate(),
-  endDate = moment().subtract(5, "months").toDate(),
+  startDate, // optional; if provided, not used as anchor (endDate is)
+  endDate, // optional; used as anchor when provided
   unitSingular = "Item",
   unitPlural = "Items",
   // Optional: [{ date: Date|string, color: string }]
   HighlightCells = [],
 }) => {
   const [displayFormat, setDisplayFormat] = useState({ id: defaultDisplay });
+  // Timeframe state (in months) and paging by timeframe-size
+  const [timeframe, setTimeframe] = useState({ id: "6" }); // "1", "3", "6"
+  const [offset, setOffset] = useState(0); // 0 = current window, -1 = previous, +1 = next
+
+  const months = Number(timeframe?.id || 6);
+  // Prefer provided endDate as anchor; otherwise use now + 1 month (existing default behavior)
+  const anchorEnd = endDate ? moment(endDate) : moment().add(1, "month");
+  const viewEndDate = anchorEnd
+    .clone()
+    .add(offset * months, "months")
+    .toDate();
+  const viewStartDate = moment(viewEndDate).subtract(months, "months").toDate();
 
   const calendarData = series?.map((d) => ({ date: d.date, value: d.count }));
   const timelineData = series?.map((d) => ({ date: d.date, qty: d.count }));
@@ -55,79 +68,136 @@ export const TimeDataFrame = ({
                 { id: "calendar", label: "Calendar" },
                 { id: "timeline", label: "Timeline" },
               ]}
+              size="sm"
             />
           </div>
         </Responsive>
-        {displayFormat?.id === "calendar" ? (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            width: "100%",
+          }}
+        >
+          {/* Controls row: buttons left, legend right */}
           <div
-            style={{ display: "flex", flexDirection: "column", width: "100%" }}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "flex-end",
+              width: "100%",
+              marginBottom: 8,
+              gap: 24,
+            }}
           >
-            {/* Legend / reference aligned top-right, no borders/background */}
-            <div
-              aria-label="Calendar reference"
-              style={{
-                display: "flex",
-                justifyContent: "flex-end",
-                alignItems: "center",
-                gap: 16,
-                marginBottom: 8,
-                width: "100%",
-              }}
-            >
-              <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                <span style={{ fontSize: 12 }}>0</span>
-                <div
-                  title={`Scale: 0 to ${maxValue}`}
-                  style={{
-                    width: 72,
-                    height: 12,
-                    background: "linear-gradient(to right, white, #066fd1)",
-                  }}
-                />
-                <span style={{ fontSize: 12 }}>{maxValue}</span>
-              </div>
-              <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                <div
-                  title="Event dates"
-                  style={{
-                    width: 12,
-                    height: 12,
-                    background: "var(--tblr-success)",
-                  }}
-                />
-                <span style={{ fontSize: 12 }}>Event dates</span>
-              </div>
-            </div>
-            <div
-              style={{
-                display: "flex",
-                justifyContent: "flex-end",
-                width: "100%",
-              }}
-            >
-              <CalendarPlot
-                data={calendarData}
-                startDate={startDate}
-                endDate={endDate}
-                highlightToday
-                todayStroke="var(--tblr-danger)"
-                todayStrokeWidth={2}
-                showCounts
-                // Pass through to calendar as lower-cased prop
-                highlightCells={HighlightCells}
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <Button size="sm" outline onClick={() => setOffset((o) => o - 1)}>
+                <Icon i="chevron-left" />
+              </Button>
+              <SegmentedControl
+                value={timeframe}
+                onChange={(v) => {
+                  setTimeframe(v);
+                  setOffset(0);
+                }}
+                items={[
+                  { id: "1", label: "1 mo" },
+                  { id: "3", label: "3 mo" },
+                  { id: "6", label: "6 mo" },
+                ]}
+                size="sm"
               />
+              <Button size="sm" outline onClick={() => setOffset((o) => o + 1)}>
+                <Icon i="chevron-right" />
+              </Button>
             </div>
+
+            {displayFormat?.id === "calendar" && (
+              <div
+                aria-label="Calendar reference"
+                style={{
+                  display: "flex",
+                  justifyContent: "flex-end",
+                  alignItems: "center",
+                  gap: 16,
+                }}
+              >
+                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  <span style={{ fontSize: 12 }}>0</span>
+                  <div
+                    title={`Scale: 0 to ${maxValue}`}
+                    style={{
+                      width: 72,
+                      height: 12,
+                      background: "linear-gradient(to right, white, #066fd1)",
+                    }}
+                  />
+                  <span style={{ fontSize: 12 }}>{maxValue}</span>
+                </div>
+                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  <div
+                    title="Event dates"
+                    style={{
+                      width: 12,
+                      height: 12,
+                      background: "var(--tblr-success)",
+                    }}
+                  />
+                  <span style={{ fontSize: 12 }}>Event dates</span>
+                </div>
+              </div>
+            )}
           </div>
-        ) : (
-          <TimeLineChart
-            data={timelineData}
-            height={150}
-            unitSingular={unitSingular}
-            unitPlural={unitPlural}
-            startDate={startDate}
-            endDate={endDate}
-          />
-        )}
+
+          {/* Graph area (fixed height to avoid clipping, right-aligned) */}
+          <div
+            style={{
+              display: "flex",
+              width: "100%",
+              justifyContent: "flex-end",
+            }}
+          >
+            {displayFormat?.id === "calendar" ? (
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "flex-end",
+                  width: "100%",
+                }}
+              >
+                <CalendarPlot
+                  data={calendarData}
+                  startDate={viewStartDate}
+                  endDate={viewEndDate}
+                  height={200}
+                  highlightToday
+                  todayStroke="var(--tblr-danger)"
+                  todayStrokeWidth={2}
+                  showCounts
+                  // Pass through to calendar as lower-cased prop
+                  highlightCells={HighlightCells}
+                />
+              </div>
+            ) : (
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "flex-end",
+                  width: "100%",
+                }}
+              >
+                <TimeLineChart
+                  data={timelineData}
+                  height={150}
+                  unitSingular={unitSingular}
+                  unitPlural={unitPlural}
+                  startDate={viewStartDate}
+                  endDate={viewEndDate}
+                />
+              </div>
+            )}
+          </div>
+        </div>
       </Responsive>
     </Card>
   );

--- a/app/components/VolunteerRegistrationStatsCard/VolunteerRegistrationStatsCard.jsx
+++ b/app/components/VolunteerRegistrationStatsCard/VolunteerRegistrationStatsCard.jsx
@@ -7,7 +7,7 @@ import { buildDate } from "../tzDateTime/tzDateTime";
 
 export const VolunteerRegistrationStatsCard = () => {
   const { eventId } = useParams();
-  const { volunteerRegistrations, registrationsByDay } = useDashVolunteers({
+  const { volunteerRegistrations, registrationsByDay, previous } = useDashVolunteers({
     eventId,
   });
   const { instance } = useSelectedInstance();
@@ -48,8 +48,18 @@ export const VolunteerRegistrationStatsCard = () => {
         date: d.date,
         count: d.count,
       }))}
+      compareSeries={previous?.registrationsByDay?.map((d) => ({
+        date: d.date,
+        count: d.count,
+      }))}
       unitSingular="Volunteer"
       unitPlural="Volunteers"
+      anchorStartDate={buildDate(instance?.startTime, instance?.startTimeTz)}
+      compareStartDate={
+        previous?.instance
+          ? buildDate(previous.instance.startTime, previous.instance.startTimeTz)
+          : undefined
+      }
       startDate={moment(buildDate(instance?.startTime, instance?.startTimeTz))
         .subtract(5, "months")
         .toDate()}

--- a/app/components/VolunteerRegistrationStatsCard/VolunteerRegistrationStatsCard.jsx
+++ b/app/components/VolunteerRegistrationStatsCard/VolunteerRegistrationStatsCard.jsx
@@ -7,7 +7,7 @@ import { buildDate } from "../tzDateTime/tzDateTime";
 
 export const VolunteerRegistrationStatsCard = () => {
   const { eventId } = useParams();
-  const { volunteerRegistrations, registrationsByDay, previous } = useDashVolunteers({
+  const { volunteerRegistrations, registrationsByDay, previous, trend } = useDashVolunteers({
     eventId,
   });
   const { instance } = useSelectedInstance();
@@ -44,6 +44,7 @@ export const VolunteerRegistrationStatsCard = () => {
       title="Volunteer Registrations"
       totalTitle="Total Volunteers"
       total={volunteerRegistrations}
+      trend={trend}
       series={registrationsByDay?.map((d) => ({
         date: d.date,
         count: d.count,

--- a/app/components/VolunteerRegistrationStatsCard/VolunteerRegistrationStatsCard.jsx
+++ b/app/components/VolunteerRegistrationStatsCard/VolunteerRegistrationStatsCard.jsx
@@ -17,11 +17,24 @@ export const VolunteerRegistrationStatsCard = () => {
   const end = buildDate(instance?.endTime, instance?.endTimeTz);
   const highlightCells = (() => {
     if (!start || !end) return [];
-    const s = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate()));
-    const e = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate()));
+    const s = new Date(
+      Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate())
+    );
+    const e = new Date(
+      Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate())
+    );
     const out = [];
-    for (let d = new Date(s); d <= e; d = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1))) {
-      out.push({ date: new Date(d), color: "rgba(var(--tblr-warning-rgb), 0.25)" });
+    for (
+      let d = new Date(s);
+      d <= e;
+      d = new Date(
+        Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1)
+      )
+    ) {
+      out.push({
+        date: new Date(d),
+        color: "var(--tblr-success)",
+      });
     }
     return out;
   })();

--- a/app/components/VolunteerRegistrationStatsCard/VolunteerRegistrationStatsCard.jsx
+++ b/app/components/VolunteerRegistrationStatsCard/VolunteerRegistrationStatsCard.jsx
@@ -52,6 +52,7 @@ export const VolunteerRegistrationStatsCard = () => {
         date: d.date,
         count: d.count,
       }))}
+      enableCalendarChangeToggle={!!previous?.registrationsByDay?.length}
       unitSingular="Volunteer"
       unitPlural="Volunteers"
       anchorStartDate={buildDate(instance?.startTime, instance?.startTimeTz)}

--- a/app/components/VolunteerRegistrationStatsCard/VolunteerRegistrationStatsCard.jsx
+++ b/app/components/VolunteerRegistrationStatsCard/VolunteerRegistrationStatsCard.jsx
@@ -1,21 +1,49 @@
 import { useParams } from "react-router-dom";
 import { useDashVolunteers } from "../../hooks/useDashVolunteers";
 import { TimeDataFrame } from "../TimeDataFrame/TimeDataFrame";
+import { useSelectedInstance } from "../../contexts/SelectedInstanceContext";
+import moment from "moment";
+import { buildDate } from "../tzDateTime/tzDateTime";
 
 export const VolunteerRegistrationStatsCard = () => {
   const { eventId } = useParams();
   const { volunteerRegistrations, registrationsByDay } = useDashVolunteers({
     eventId,
   });
+  const { instance } = useSelectedInstance();
+
+  // Build inclusive day range highlight from instance start/end
+  const start = buildDate(instance?.startTime, instance?.startTimeTz);
+  const end = buildDate(instance?.endTime, instance?.endTimeTz);
+  const highlightCells = (() => {
+    if (!start || !end) return [];
+    const s = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate()));
+    const e = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate()));
+    const out = [];
+    for (let d = new Date(s); d <= e; d = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1))) {
+      out.push({ date: new Date(d), color: "rgba(var(--tblr-warning-rgb), 0.25)" });
+    }
+    return out;
+  })();
 
   return (
     <TimeDataFrame
       title="Volunteer Registrations"
       totalTitle="Total Volunteers"
       total={volunteerRegistrations}
-      series={registrationsByDay?.map((d) => ({ date: d.date, count: d.count }))}
+      series={registrationsByDay?.map((d) => ({
+        date: d.date,
+        count: d.count,
+      }))}
       unitSingular="Volunteer"
       unitPlural="Volunteers"
+      startDate={moment(buildDate(instance?.startTime, instance?.startTimeTz))
+        .subtract(5, "months")
+        .toDate()}
+      endDate={moment(buildDate(instance?.endTime, instance?.endTimeTz))
+        .add(1, "months")
+        .toDate()}
+      HighlightCells={highlightCells}
     />
   );
 };

--- a/app/components/VolunteerRegistrationStatsCard/VolunteerRegistrationStatsCard.jsx
+++ b/app/components/VolunteerRegistrationStatsCard/VolunteerRegistrationStatsCard.jsx
@@ -7,7 +7,7 @@ import { buildDate } from "../tzDateTime/tzDateTime";
 
 export const VolunteerRegistrationStatsCard = () => {
   const { eventId } = useParams();
-  const { volunteerRegistrations, registrationsByDay, previous, trend } = useDashVolunteers({
+  const { volunteerRegistrations, registrationsByDay, previous, trend, loading } = useDashVolunteers({
     eventId,
   });
   const { instance } = useSelectedInstance();
@@ -45,6 +45,11 @@ export const VolunteerRegistrationStatsCard = () => {
       totalTitle="Total Volunteers"
       total={volunteerRegistrations}
       trend={trend}
+      loading={loading}
+      loadingTitle="Loading volunteer stats"
+      loadingText="Pulling in volunteer registrations by day..."
+      emptyTitle="No volunteer registrations yet"
+      emptyText="Share your volunteer signup link to start seeing activity here."
       series={registrationsByDay?.map((d) => ({
         date: d.date,
         count: d.count,

--- a/app/components/dataBox/DataBox.jsx
+++ b/app/components/dataBox/DataBox.jsx
@@ -1,9 +1,9 @@
 import styles from "./databox.module.css";
 import { Typography } from "tabler-react-2";
-import { Row } from "../../util/Flex";
 import classNames from "classnames";
+import { Icon } from "../../util/Icon";
 
-export const DataBox = ({ title, description, value }) => {
+export const DataBox = ({ title, description, value, trend = null }) => {
   return (
     <div className={styles.dataBox}>
       <div className={styles.dataBoxHeader}>
@@ -12,6 +12,25 @@ export const DataBox = ({ title, description, value }) => {
           {value}
         </Typography.Text>
       </div>
+      {!!trend && (
+        <div className={styles.dataBoxTrend}>
+          <Icon
+            i={Number(trend?.delta ?? 0) >= 0 ? "trending-up" : "trending-down"}
+            color={
+              Number(trend?.delta ?? 0) >= 0
+                ? "var(--tblr-success)"
+                : "var(--tblr-danger)"
+            }
+            size={16}
+          />
+          <Typography.Text className="mb-0">
+            {trend?.percentChange != null
+              ? `${trend.percentChange.toFixed(1)}%`
+              : "—"}{" "}
+            vs last ({Number(trend?.previousAsOf ?? 0)})
+          </Typography.Text>
+        </div>
+      )}
       {description && (
         <div className={styles.dataBoxDescription}>
           <Typography.Text>{description}</Typography.Text>

--- a/app/components/dataBox/databox.module.css
+++ b/app/components/dataBox/databox.module.css
@@ -9,3 +9,10 @@
 .value {
   font-size: 2rem;
 }
+
+.dataBoxTrend {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+}

--- a/app/components/plots/calendar.jsx
+++ b/app/components/plots/calendar.jsx
@@ -15,6 +15,7 @@ export const CalendarPlot = ({
   showCounts = false, // show count text if > 0
   showDates = false, // show the date number in each cell
   highlightCells = [], // [{ date: Date|string, color: string }]
+  height, // optional fixed plot height to avoid growing with width
 }) => {
   const ref = useRef(null);
 
@@ -55,8 +56,7 @@ export const CalendarPlot = ({
     }
 
     const max = d3.max(cells, (d) => d.value ?? 0) ?? 0;
-    const weeks =
-      1 + d3.utcWeek.count(d3.utcSunday.floor(lo), d3.utcSunday.floor(hi));
+    const weeks = 1 + d3.utcWeek.count(d3.utcSunday.floor(lo), d3.utcSunday.floor(hi));
 
     const weekdayOrder = [1, 2, 3, 4, 5, 6, 0];
     const weekdayLabels = weekdayOrder.map((dow) => ({
@@ -97,13 +97,35 @@ export const CalendarPlot = ({
 
     const highlightedCells = cells.filter((c) => !!c.highlightColor);
 
+    const marginTop = 28;
+    const marginLeft = 36;
+    const marginRight = 2;
+    const marginBottom = 2;
+
+    // Choose plot dimensions to maintain square day cells.
+    // If a height is provided, derive width from it. Otherwise, derive height from width.
+    let plotHeight;
+    let plotWidth;
+    if (height != null) {
+      const innerH = Math.max(1, height - (marginTop + marginBottom));
+      const cell = Math.max(6, Math.floor(innerH / 7));
+      plotHeight = cell * 7 + marginTop + marginBottom;
+      const innerW = cell * Math.max(1, weeks);
+      plotWidth = innerW + marginLeft + marginRight;
+    } else {
+      const innerW = Math.max(1, (width ?? 720) - (marginLeft + marginRight));
+      const cell = Math.max(6, Math.floor(innerW / Math.max(1, weeks)));
+      plotHeight = cell * 7 + marginTop + marginBottom;
+      plotWidth = (width ?? 720);
+    }
+
     const plot = Plot.plot({
-      width,
-      height: Math.max(7 * Math.floor(width / Math.max(weeks, 1)), 70),
-      marginTop: 28,
-      marginLeft: 36,
-      marginRight: 2,
-      marginBottom: 2,
+      width: plotWidth,
+      height: plotHeight,
+      marginTop,
+      marginLeft,
+      marginRight,
+      marginBottom,
       style: {
         overflow: "visible",
         fontFamily: "var(--tblr-body-font-family)",
@@ -242,6 +264,7 @@ export const CalendarPlot = ({
     showCounts,
     showDates, // ensure toggling re-renders
     highlightCells,
+    height,
   ]);
 
   return <div ref={ref} />;

--- a/app/components/plots/calendar.jsx
+++ b/app/components/plots/calendar.jsx
@@ -95,7 +95,6 @@ export const CalendarPlot = ({
 
     const fmtDate = d3.utcFormat("%a, %b %-d, %Y");
 
-    const baseCells = cells.filter((c) => !c.highlightColor);
     const highlightedCells = cells.filter((c) => !!c.highlightColor);
 
     const plot = Plot.plot({
@@ -143,8 +142,8 @@ export const CalendarPlot = ({
           fontFamily: "var(--tblr-body-font-family)",
         }),
 
-        // Heatmap cells (non-highlighted)
-        Plot.rect(baseCells, {
+        // Heatmap cells (all)
+        Plot.rect(cells, {
           x1: "x1",
           x2: "x2",
           y1: "y1",
@@ -155,7 +154,7 @@ export const CalendarPlot = ({
           tip: { anchor: "top", pointer: "move" },
         }),
 
-        // Highlighted cells (override background color)
+        // Highlighted cells (override background color) — visual-only layer
         ...(highlightedCells.length
           ? [
               Plot.rect(highlightedCells, {
@@ -165,8 +164,8 @@ export const CalendarPlot = ({
                 y2: "y2",
                 fill: (d) => d.highlightColor,
                 inset: 0.75,
-                title: (d) => `${fmtDate(d.date)} — ${d.value ?? 0}`,
-                tip: { anchor: "top", pointer: "move" },
+                pointerEvents: "none",
+                ariaHidden: true,
               }),
             ]
           : []),
@@ -219,6 +218,8 @@ export const CalendarPlot = ({
                 fill: "none",
                 stroke: todayStroke,
                 strokeWidth: todayStrokeWidth,
+                pointerEvents: "none",
+                ariaHidden: true,
               }),
             ]
           : []),

--- a/app/components/plots/timeline.jsx
+++ b/app/components/plots/timeline.jsx
@@ -26,8 +26,16 @@ export const TimeLineChart = ({
       const safeData = Array.isArray(data) ? data : [];
 
       // Determine x-domain: prefer provided start/end dates; otherwise infer from data.
-      const xLo = startDate ? new Date(startDate) : (safeData[0] ? new Date(safeData[0].date) : undefined);
-      const xHi = endDate ? new Date(endDate) : (safeData[safeData.length - 1] ? new Date(safeData[safeData.length - 1].date) : undefined);
+      const xLo = startDate
+        ? new Date(startDate)
+        : safeData[0]
+        ? new Date(safeData[0].date)
+        : undefined;
+      const xHi = endDate
+        ? new Date(endDate)
+        : safeData[safeData.length - 1]
+        ? new Date(safeData[safeData.length - 1].date)
+        : undefined;
       let xDomain;
       if (xLo && xHi) {
         xDomain = xLo <= xHi ? [xLo, xHi] : [xHi, xLo];
@@ -41,12 +49,18 @@ export const TimeLineChart = ({
 
       // Choose sensible x tick interval based on range length (days).
       const msPerDay = 24 * 60 * 60 * 1000;
-      const daySpan = xDomain ? Math.max(1, Math.round((xDomain[1] - xDomain[0]) / msPerDay)) : safeData.length;
+      const daySpan = xDomain
+        ? Math.max(1, Math.round((xDomain[1] - xDomain[0]) / msPerDay))
+        : safeData.length;
       const xTicks = daySpan > 14 ? "week" : "day";
 
       // Build mapped comparison data aligned to the current instance by day-offset.
       const mappedCompare = (() => {
-        if (!Array.isArray(compareData) || !anchorStartDate || !compareStartDate)
+        if (
+          !Array.isArray(compareData) ||
+          !anchorStartDate ||
+          !compareStartDate
+        )
           return [];
         const anchor = new Date(anchorStartDate);
         const prevStart = new Date(compareStartDate);
@@ -97,12 +111,14 @@ export const TimeLineChart = ({
                   x: "date",
                   y: "qty",
                   fill: "url(#gradient)",
+                  clip: true,
                 }),
                 Plot.line(safeData, {
                   x: "date",
                   y: "qty",
                   stroke: "var(--tblr-primary)",
                   strokeWidth: 2,
+                  clip: true,
                 }),
                 // Historical overlay (previous instance mapped to current axis)
                 ...(mappedCompare.length
@@ -110,9 +126,10 @@ export const TimeLineChart = ({
                       Plot.line(mappedCompare, {
                         x: "date",
                         y: "qty",
-                        stroke: "var(--tblr-warning)",
-                        strokeWidth: 2,
+                        stroke: "var(--tblr-secondary)",
+                        strokeWidth: 1,
                         strokeDasharray: "5,3",
+                        clip: true,
                       }),
                     ]
                   : []),
@@ -122,6 +139,7 @@ export const TimeLineChart = ({
                     x: "date",
                     py: "qty",
                     stroke: "var(--tblr-danger)",
+                    clip: true,
                   })
                 ),
                 Plot.dot(
@@ -130,6 +148,7 @@ export const TimeLineChart = ({
                     x: "date",
                     y: "qty",
                     stroke: "var(--tblr-danger)",
+                    clip: true,
                   })
                 ),
                 Plot.text(
@@ -140,6 +159,7 @@ export const TimeLineChart = ({
                     dy: -16,
                     frameAnchor: "top-left",
                     fontVariant: "tabular-nums",
+                    clip: true,
                     text: (d) =>
                       [
                         `Date ${moment(d.date).format("M/D/YY")}`,

--- a/app/components/plots/timeline.jsx
+++ b/app/components/plots/timeline.jsx
@@ -167,10 +167,9 @@ export const TimeLineChart = ({
                     clip: true,
                   })
                 ),
-                // HTML tooltip near cursor using Plot.tip
-                Plot.tip(
-                  visibleData,
-                  Plot.pointerX({
+                // HTML tooltip near cursor using Plot.tip; clipped to plot area
+                Plot.tip(visibleData, {
+                  ...Plot.pointerX({
                     x: "date",
                     y: "qty",
                     title: (d) => {
@@ -191,8 +190,9 @@ export const TimeLineChart = ({
                       }
                       return parts.join("\n");
                     },
-                  })
-                ),
+                  }),
+                  clip: true,
+                }),
               ]
             : []),
         ],

--- a/app/components/tzDateTime/tzDateTime.jsx
+++ b/app/components/tzDateTime/tzDateTime.jsx
@@ -5,6 +5,15 @@ import { Row } from "../../util/Flex";
 import timezones from "./tzs.json";
 import classNames from "classnames";
 
+export const buildDate = (date, tzValue) => {
+  if (!date || !tzValue) return "";
+  const zone = timezones.find((t) => t.value === tzValue)?.utc[0];
+  if (!zone) return "";
+
+  const m = moment.tz(date, zone);
+  return m.toDate();
+};
+
 export const formatDate = (date, tzValue, format = "MMM DD, h:mm a") => {
   if (!date || !tzValue) return "";
 

--- a/app/hooks/useDashParticipants.jsx
+++ b/app/hooks/useDashParticipants.jsx
@@ -10,9 +10,9 @@ export const useDashParticipants = ({ eventId }) => {
   return {
     participantRegistrations: data?.participantRegistrations,
     registrationsByDay: data?.registrationsByDay,
+    previous: data?.previous || null,
     loading: isLoading,
     error,
     refetch: () => (key ? mutate(key) : undefined),
   };
 };
-

--- a/app/hooks/useDashVolunteers.jsx
+++ b/app/hooks/useDashVolunteers.jsx
@@ -10,6 +10,7 @@ export const useDashVolunteers = ({ eventId }) => {
   return {
     volunteerRegistrations: data?.volunteerRegistrations,
     registrationsByDay: data?.registrationsByDay,
+    previous: data?.previous || null,
     loading: isLoading,
     error,
     refetch: () => mutate(key),

--- a/app/hooks/useDashVolunteers.jsx
+++ b/app/hooks/useDashVolunteers.jsx
@@ -10,6 +10,7 @@ export const useDashVolunteers = ({ eventId }) => {
   return {
     volunteerRegistrations: data?.volunteerRegistrations,
     registrationsByDay: data?.registrationsByDay,
+    trend: data?.trend || null,
     previous: data?.previous || null,
     loading: isLoading,
     error,


### PR DESCRIPTION
This pull request adds support for comparing participant and volunteer registration metrics between the current and previous event instances, as well as improving the visualization and user experience for registration statistics. The main changes include backend enhancements to fetch and compute comparison data, and frontend updates to display these comparisons and provide a more informative and interactive stats card.

**Backend: Comparison Data and Trends for Event Instances**
- Both `participants.js` and `volunteers.js` API routes now fetch the previous event instance (if any) for the current event and compute registration counts by day for both current and previous instances, enabling overlay comparison in the frontend. ([api/routes/events/[eventId]/dash/participants.jsR11-R27](diffhunk://#diff-6d20911a38cec37ad4819acd506d73be628bca043bca3c2baf61954ce4c82f0aR11-R27), [api/routes/events/[eventId]/dash/volunteers.jsR11-R27](diffhunk://#diff-df3ae89d2f1800a08705ede34575dfbddc22a84a845d9feb01f87d9b1b50ad2cR11-R27))
- The volunteers API additionally computes a "trend" metric, comparing current totals to the previous instance at the same relative day offset from the start, including delta and percent change. ([api/routes/events/[eventId]/dash/volunteers.jsR51-R127](diffhunk://#diff-df3ae89d2f1800a08705ede34575dfbddc22a84a845d9feb01f87d9b1b50ad2cR51-R127))

**Frontend: Enhanced Stats Card and Time Series Visualization**
- `ParticipantRegistrationStatsCard.jsx` now displays the current and previous instance registration series for comparison, highlights the active instance date range, and passes more contextual props to the `TimeDataFrame` component.
- `TimeDataFrame.jsx` is refactored to support loading and empty states, overlay comparison series, dynamic date range navigation, and (for volunteers) the display of trend metrics. It also introduces logic for per-day change visualization between current and previous instances. [[1]](diffhunk://#diff-d71d365bbb15271dd1497ef68d10f8076de5f5af600d10f33ec382304ee532ceL1-R10) [[2]](diffhunk://#diff-d71d365bbb15271dd1497ef68d10f8076de5f5af600d10f33ec382304ee532ceR20-R128) [[3]](diffhunk://#diff-d71d365bbb15271dd1497ef68d10f8076de5f5af600d10f33ec382304ee532ceL45-R143)