### PR TITLE
Implement Rrweb tracking

### DIFF
--- a/api/prisma/migrations/20250906135436_add_session_recording/migration.sql
+++ b/api/prisma/migrations/20250906135436_add_session_recording/migration.sql
@@ -1,0 +1,40 @@
+-- CreateTable
+CREATE TABLE "Session" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "instanceId" TEXT NOT NULL,
+    "fileId" TEXT NOT NULL,
+    "registrationId" TEXT,
+    "volunteerRegistrationId" TEXT,
+    "path" TEXT,
+    "pageType" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Session_eventId_instanceId_idx" ON "Session"("eventId", "instanceId");
+
+-- CreateIndex
+CREATE INDEX "Session_registrationId_idx" ON "Session"("registrationId");
+
+-- CreateIndex
+CREATE INDEX "Session_volunteerRegistrationId_idx" ON "Session"("volunteerRegistrationId");
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_instanceId_fkey" FOREIGN KEY ("instanceId") REFERENCES "EventInstance"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_fileId_fkey" FOREIGN KEY ("fileId") REFERENCES "File"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_registrationId_fkey" FOREIGN KEY ("registrationId") REFERENCES "Registration"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_volunteerRegistrationId_fkey" FOREIGN KEY ("volunteerRegistrationId") REFERENCES "FormResponse"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/prisma/migrations/20250906141759_rrweb_session_tracking/migration.sql
+++ b/api/prisma/migrations/20250906141759_rrweb_session_tracking/migration.sql
@@ -1,0 +1,37 @@
+-- CreateEnum
+CREATE TYPE "SessionTerminationReason" AS ENUM ('UNLOAD', 'CLOSE');
+
+-- AlterTable
+ALTER TABLE "Session" ADD COLUMN     "active" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "converted" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "endedAt" TIMESTAMP(3),
+ADD COLUMN     "geolocationId" TEXT,
+ADD COLUMN     "ip" TEXT,
+ADD COLUMN     "startedAt" TIMESTAMP(3),
+ADD COLUMN     "terminationReason" "SessionTerminationReason",
+ALTER COLUMN "fileId" DROP NOT NULL;
+
+-- CreateTable
+CREATE TABLE "SessionChunk" (
+    "id" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "fileId" TEXT NOT NULL,
+    "startedAt" TIMESTAMP(3) NOT NULL,
+    "endedAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SessionChunk_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SessionChunk_sessionId_idx" ON "SessionChunk"("sessionId");
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_geolocationId_fkey" FOREIGN KEY ("geolocationId") REFERENCES "Geolocation"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SessionChunk" ADD CONSTRAINT "SessionChunk_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "Session"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SessionChunk" ADD CONSTRAINT "SessionChunk_fileId_fkey" FOREIGN KEY ("fileId") REFERENCES "File"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/migrations/20250906142126_make_instance_optional/migration.sql
+++ b/api/prisma/migrations/20250906142126_make_instance_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Session" ALTER COLUMN "instanceId" DROP NOT NULL;

--- a/api/prisma/migrations/20250906144923_remove_file_from_session/migration.sql
+++ b/api/prisma/migrations/20250906144923_remove_file_from_session/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `fileId` on the `Session` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Session" DROP CONSTRAINT "Session_fileId_fkey";
+
+-- AlterTable
+ALTER TABLE "Session" DROP COLUMN "fileId";

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -32,8 +32,8 @@ model User {
 
   suspended Boolean @default(false)
 
-  events Event[]
-  emails Email[]
+  events          Event[]
+  emails          Email[]
   gmailConnection GmailConnection[]
 }
 
@@ -243,13 +243,14 @@ enum EmailWebhookType {
 }
 
 model Geolocation {
-  id         String   @id @default(cuid())
-  ip         String   @unique
+  id         String    @id @default(cuid())
+  ip         String    @unique
   city       String?
   regionName String?
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
   logs       Logs[]
+  Session    Session[]
 }
 
 model File {
@@ -278,7 +279,74 @@ model File {
   inboundEmailAttachment   InboundEmailAttachment? @relation("FileAttachment")
   inboundEmailAttachmentId String?                 @unique
 
-  logs Logs[]
+  logs         Logs[]
+  SessionChunk SessionChunk[]
+}
+
+/// Records rrweb consumer session captures and associations
+model Session {
+  id String @id @default(cuid())
+
+  eventId String
+  event   Event  @relation(fields: [eventId], references: [id], onDelete: Cascade)
+
+  instanceId String?
+  instance   EventInstance? @relation(fields: [instanceId], references: [id], onDelete: Cascade)
+
+
+  // Optional links to created records
+  registrationId          String?
+  registration            Registration?          @relation(fields: [registrationId], references: [id], onDelete: SetNull)
+  volunteerRegistrationId String?
+  volunteerRegistration   VolunteerRegistration? @relation(fields: [volunteerRegistrationId], references: [id], onDelete: SetNull)
+
+  // Request context
+  path      String?
+  pageType  String?
+  metadata  Json?
+  startedAt DateTime?
+  endedAt   DateTime?
+
+  // Analytics state
+  active            Boolean                   @default(true)
+  converted         Boolean                   @default(false)
+  terminationReason SessionTerminationReason?
+
+  // Networking context
+  ip            String?
+  geolocationId String?
+  geolocation   Geolocation? @relation(fields: [geolocationId], references: [id], onDelete: SetNull)
+
+  createdAt    DateTime       @default(now())
+  updatedAt    DateTime       @updatedAt
+  SessionChunk SessionChunk[]
+
+  @@index([eventId, instanceId])
+  @@index([registrationId])
+  @@index([volunteerRegistrationId])
+}
+
+model SessionChunk {
+  id String @id @default(cuid())
+
+  sessionId String
+  session   Session @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+
+  fileId String
+  file   File   @relation(fields: [fileId], references: [id], onDelete: Cascade)
+
+  startedAt DateTime
+  endedAt   DateTime
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([sessionId])
+}
+
+enum SessionTerminationReason {
+  UNLOAD
+  CLOSE
 }
 
 model Event {
@@ -340,13 +408,13 @@ model Event {
   crmPersons          CrmPerson[]
   crmFields           CrmField[]
   crmPersonImports    CrmPersonsImport[]
-  inboundEmails       InboundEmail[]       @relation(name: "Event_InboundEmails")
+  inboundEmails       InboundEmail[]               @relation(name: "Event_InboundEmails")
   conversations       Conversation[]
   registrationTiers   RegistrationTier[]
   registrationPeriods RegistrationPeriod[]
   registrationUpsells UpsellItem[]
   /// Saved CRM AI segments / searches
-  crmSavedSegments CrmSavedSegment[]
+  crmSavedSegments    CrmSavedSegment[]
   registrationFields  RegistrationField[]
   registrations       Registration[]
   teams               Team[]
@@ -356,9 +424,9 @@ model Event {
 
   stripeConnectedAccountId  String?
   // EventPilot billing: subscription for this event in Stripe
-  stripe_subscriptionId     String?   @unique
-  stripe_customerId         String?   @unique
-  goodPaymentStanding       Boolean   @default(false)
+  stripe_subscriptionId     String?                     @unique
+  stripe_customerId         String?                     @unique
+  goodPaymentStanding       Boolean                     @default(false)
   RegistrationPeriodPricing RegistrationPeriodPricing[]
   RegistrationFieldResponse RegistrationFieldResponse[]
 
@@ -367,16 +435,17 @@ model Event {
 
   // Configuration 1:1
   configuration Configuration?
+  Session       Session[]
 }
 
 model GmailConnection {
-  id           String   @id @default(cuid())
+  id String @id @default(cuid())
 
   eventId String
-  event   Event   @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  event   Event  @relation(fields: [eventId], references: [id], onDelete: Cascade)
 
   createdById String?
-  createdBy   User?    @relation(fields: [createdById], references: [id], onDelete: SetNull)
+  createdBy   User?   @relation(fields: [createdById], references: [id], onDelete: SetNull)
 
   googleUserId String
   email        String
@@ -427,6 +496,7 @@ model EventInstance {
   RegistrationField         RegistrationField[]
   RegistrationFieldResponse RegistrationFieldResponse[]
   coupons                   Coupon[]
+  Session                   Session[]
 }
 
 model LedgerItem {
@@ -439,7 +509,7 @@ model LedgerItem {
   instance   EventInstance @relation(fields: [instanceId], references: [id], onDelete: Cascade)
 
   // Net amount (after discounts/coupons)
-  amount Float
+  amount         Float
   // Original amount before discounts/coupons
   originalAmount Float?
 
@@ -517,26 +587,27 @@ model VolunteerRegistrationField {
   instance   EventInstance @relation(fields: [instanceId], references: [id], onDelete: Cascade)
 
   logs Logs[]
+
   @@map("FormField")
 }
 
 model VolunteerRegistrationFieldOption {
-  id      String    @id @default(cuid())
+  id      String                     @id @default(cuid())
   fieldId String
   field   VolunteerRegistrationField @relation(fields: [fieldId], references: [id], onDelete: Cascade)
   label   String
   order   Int
-  deleted Boolean   @default(false)
+  deleted Boolean                    @default(false)
 
   @@index([fieldId])
   @@map("FormFieldOption")
 }
 
 model VolunteerRegistration {
-  id             String          @id @default(cuid())
+  id             String                        @id @default(cuid())
   fieldResponses VolunteerRegistrationAnswer[]
   pii            PII?
-  deleted        Boolean         @default(false)
+  deleted        Boolean                       @default(false)
 
   crmPersonLink CrmPersonLink?
 
@@ -549,15 +620,17 @@ model VolunteerRegistration {
   instanceId String
   instance   EventInstance @relation(fields: [instanceId], references: [id], onDelete: Cascade)
 
-  logs   Logs[]
-  shifts VolunteerShiftSignup[]
+  logs    Logs[]
+  shifts  VolunteerShiftSignup[]
+  Session Session[]
+
   @@map("FormResponse")
 }
 
 model PII {
   id String @id @default(cuid())
 
-  formResponseId String?       @unique
+  formResponseId String?                @unique
   formResponse   VolunteerRegistration? @relation(fields: [formResponseId], references: [id], onDelete: Cascade)
 
   userAgent    String?
@@ -576,15 +649,15 @@ model PII {
 }
 
 model VolunteerRegistrationAnswer {
-  id         String       @id @default(cuid())
+  id String @id @default(cuid())
 
   responseId String
   response   VolunteerRegistration @relation(fields: [responseId], references: [id], onDelete: Cascade)
 
-  fieldId    String
-  field      VolunteerRegistrationField    @relation(fields: [fieldId], references: [id], onDelete: Cascade)
+  fieldId String
+  field   VolunteerRegistrationField @relation(fields: [fieldId], references: [id], onDelete: Cascade)
 
-  value      String?
+  value String?
 
   @@index([responseId])
   @@index([fieldId])
@@ -743,7 +816,7 @@ model CrmPersonLink {
   crmPersonId String
   crmPerson   CrmPerson @relation(fields: [crmPersonId], references: [id], onDelete: Cascade)
 
-  formResponseId String?       @unique
+  formResponseId String?                @unique
   formResponse   VolunteerRegistration? @relation(fields: [formResponseId], references: [id], onDelete: Cascade)
 
   createdAt DateTime @default(now())
@@ -926,8 +999,8 @@ model Team {
   maxSize       Int?
   registrations Registration[]
 
-  public  Boolean @default(false)
-  deleted Boolean @default(false)
+  public    Boolean  @default(false)
+  deleted   Boolean  @default(false)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
@@ -981,7 +1054,7 @@ model Coupon {
   instance   EventInstance @relation(fields: [instanceId], references: [id], onDelete: Cascade)
 
   title        String
-  code         String @unique
+  code         String             @unique
   discountType CouponDiscountType
   amount       Float
   appliesTo    CouponAppliesTo
@@ -1037,6 +1110,7 @@ model Registration {
   coupon   Coupon? @relation(fields: [couponId], references: [id])
 
   ledgerItems LedgerItem[]
+  Session     Session[]
 }
 
 model RegistrationUpsell {
@@ -1276,13 +1350,13 @@ model Configuration {
 
   // Volunteer stats card preferences
   volunteerStatsDisplayFormat  String @default("calendar") // "calendar" | "timeline"
-  volunteerStatsCalendarMetric String @default("count")    // "count" | "change"
-  volunteerStatsTimeframe      String @default("6")        // "1" | "3" | "6" (months)
+  volunteerStatsCalendarMetric String @default("count") // "count" | "change"
+  volunteerStatsTimeframe      String @default("6") // "1" | "3" | "6" (months)
 
   // Participant stats card preferences
   participantStatsDisplayFormat  String @default("calendar") // "calendar" | "timeline"
-  participantStatsCalendarMetric String @default("count")    // "count" | "change"
-  participantStatsTimeframe      String @default("6")        // "1" | "3" | "6" (months)
+  participantStatsCalendarMetric String @default("count") // "count" | "change"
+  participantStatsTimeframe      String @default("6") // "1" | "3" | "6" (months)
 
   // CRM filter persistence (manual + AI)
   crmFilters Json?

--- a/api/routes/events/[eventId]/registration/consumer.js
+++ b/api/routes/events/[eventId]/registration/consumer.js
@@ -171,6 +171,18 @@ export const post = [
             data: inserts,
           });
 
+          // Derive participant name/email from incoming responses (needed for CRM linking and pricing)
+          const nameFieldId = fieldTypes.find(
+            (f) => f.fieldType === "participantName"
+          )?.id;
+          const emailFieldId = fieldTypes.find(
+            (f) => f.fieldType === "participantEmail"
+          )?.id;
+          const participantName = nameFieldId ? responses[nameFieldId] : null;
+          const participantEmail = emailFieldId
+            ? responses[emailFieldId]
+            : null;
+
           // 2b) Link this registration to a CRM person immediately upon submission
           if (participantEmail) {
             let existingCrmPerson = await tx.crmPerson.findFirst({
@@ -303,18 +315,6 @@ export const post = [
               data: { couponId: found.id },
             });
           }
-
-          // Derive participant name/email from incoming responses (avoids DB reads inside tx)
-          const nameFieldId = fieldTypes.find(
-            (f) => f.fieldType === "participantName"
-          )?.id;
-          const emailFieldId = fieldTypes.find(
-            (f) => f.fieldType === "participantEmail"
-          )?.id;
-          const participantName = nameFieldId ? responses[nameFieldId] : null;
-          const participantEmail = emailFieldId
-            ? responses[emailFieldId]
-            : null;
 
           const [requiresPayment, stripePIClientSecret, price] =
             await registrationRequiresPayment(

--- a/api/routes/events/[eventId]/registration/consumer.js
+++ b/api/routes/events/[eventId]/registration/consumer.js
@@ -16,6 +16,8 @@ const registrationSubmissionSchema = z.object({
   selectedTeamId: z.string().optional().nullable(),
   enteredTeamCode: z.string().max(32).optional().nullable(),
   couponCode: z.string().max(32).optional().nullable(),
+  // Optional rrweb session to link conversion
+  sessionId: z.string().optional().nullable(),
 });
 
 export const get = [
@@ -120,6 +122,7 @@ export const post = [
         selectedTeamId,
         enteredTeamCode,
         couponCode,
+        sessionId,
       } = parsed.data;
 
       const fieldIds = Object.keys(responses);
@@ -381,6 +384,21 @@ export const post = [
       );
 
       const { requiresPayment, registrationId, price } = transaction;
+
+      // Best-effort: link rrweb session to the newly created registration and mark converted
+      if (sessionId && registrationId) {
+        try {
+          await prisma.session.updateMany({
+            where: { id: sessionId, eventId },
+            data: {
+              registrationId,
+              converted: true,
+            },
+          });
+        } catch (e) {
+          console.warn("Failed to link session to registration", e);
+        }
+      }
 
       if (!requiresPayment) {
         const { crmPersonId } = await finalizeRegistration({

--- a/api/routes/events/[eventId]/sessions/[sessionId].js
+++ b/api/routes/events/[eventId]/sessions/[sessionId].js
@@ -1,0 +1,100 @@
+import { prisma } from "#prisma";
+import { uploadFile } from "#file";
+
+/**
+ * POST /api/events/:eventId/sessions/:sessionId
+ * Body: {
+ *   chunk: {
+ *     fileB64: string,            // base64 of JSON {events...}
+ *     filename: string,           // e.g. rrweb-<sessionId>-<ts>.json
+ *     contentType: "application/json",
+ *     startedAt: number,          // ms epoch
+ *     endedAt: number             // ms epoch
+ *   },
+ *   finalize?: boolean,
+ *   terminationReason?: "UNLOAD" | "CLOSE",
+ *   pageType?, path?
+ * }
+ */
+
+export const post = [
+  async (req, res) => {
+    try {
+      const { eventId, sessionId } = req.params;
+      const {
+        chunk,
+        finalize = false,
+        terminationReason = null,
+        pageType,
+        path,
+      } = req.body ?? {};
+
+      if (!chunk?.fileB64 || !chunk?.filename || !chunk?.contentType) {
+        return res.status(400).json({ message: "Missing chunk payload" });
+      }
+
+      // Ensure the session exists & belongs to the event
+      const session = await prisma.session.findFirst({
+        where: { id: sessionId, eventId },
+        select: { id: true, startedAt: true },
+      });
+      if (!session) {
+        return res.status(404).json({ message: "Session not found" });
+      }
+
+      // Store the JSON chunk in S3 via your uploadFile helper
+      const uploaded = await uploadFile({
+        file: chunk.fileB64,
+        name: chunk.filename,
+        contentType: chunk.contentType || "application/json",
+      });
+
+      // Create SessionChunk row
+      const startedAt =
+        typeof chunk.startedAt === "number"
+          ? new Date(chunk.startedAt)
+          : new Date();
+      const endedAt =
+        typeof chunk.endedAt === "number"
+          ? new Date(chunk.endedAt)
+          : new Date();
+
+      await prisma.sessionChunk.create({
+        data: {
+          sessionId: sessionId,
+          fileId: uploaded.id,
+          startedAt,
+          endedAt,
+        },
+      });
+
+      // Optional: update some rolling metadata for convenience (page/path drifting)
+      if (pageType || path) {
+        await prisma.session.update({
+          where: { id: sessionId },
+          data: {
+            pageType: pageType ?? undefined,
+            path: path ?? undefined,
+          },
+        });
+      }
+
+      // Finalize if requested
+      if (finalize) {
+        await prisma.session.update({
+          where: { id: sessionId },
+          data: {
+            active: false,
+            endedAt,
+            terminationReason: terminationReason || null,
+          },
+        });
+      }
+
+      res.json({ ok: true, fileId: uploaded.id });
+    } catch (err) {
+      console.error("Upload/Finalize session error:", err);
+      res.status(500).json({ message: "Failed to persist session chunk" });
+    }
+  },
+];

--- a/api/routes/events/[eventId]/sessions/index.js
+++ b/api/routes/events/[eventId]/sessions/index.js
@@ -1,0 +1,48 @@
+import { prisma } from "#prisma";
+import { uploadFile } from "#file";
+
+/**
+ * POST /api/events/:eventId/sessions
+ * Body: {
+ *   instanceId?,
+ *   pageType?,
+ *   path?,
+ *   metadata?: { startedAt?: number, userAgent?: string, ... }
+ * }
+ * Returns: { id }
+ */
+export const post = [
+  async (req, res) => {
+    try {
+      const { eventId } = req.params;
+      const { instanceId, pageType, path, metadata } = req.body ?? {};
+
+      const ip =
+        req.headers["x-forwarded-for"]?.split(",")[0]?.trim() ||
+        req.connection?.remoteAddress ||
+        null;
+
+      const session = await prisma.session.create({
+        data: {
+          eventId,
+          instanceId: instanceId || null,
+          pageType: pageType || null,
+          path: path || req.path || null,
+          metadata: metadata || {},
+          startedAt:
+            metadata?.startedAt != null
+              ? new Date(Number(metadata.startedAt))
+              : new Date(),
+          ip,
+          active: true,
+        },
+        select: { id: true },
+      });
+
+      res.json(session);
+    } catch (err) {
+      console.error("Create session error:", err);
+      res.status(500).json({ message: "Failed to create session" });
+    }
+  },
+];

--- a/api/routes/events/[eventId]/sessions/index.js
+++ b/api/routes/events/[eventId]/sessions/index.js
@@ -1,5 +1,4 @@
 import { prisma } from "#prisma";
-import { uploadFile } from "#file";
 
 /**
  * POST /api/events/:eventId/sessions

--- a/api/scripts/testUpload.js
+++ b/api/scripts/testUpload.js
@@ -1,0 +1,17 @@
+import { uploadFile } from "#file";
+
+const b46encode = (str) =>
+  Buffer.from(str, "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+
+const uf = await uploadFile({
+  file: b46encode("test"),
+  name: "test.txt",
+  contentType: "text/plain",
+  contentLength: 4,
+});
+
+console.log(uf);

--- a/app/components/ConsumerPage/ConsumerPage.jsx
+++ b/app/components/ConsumerPage/ConsumerPage.jsx
@@ -6,6 +6,7 @@ import styles from "./ConsumerPage.module.css";
 import classNames from "classnames";
 import { Loading } from "../loading/Loading";
 import { useTitle } from "react-use";
+import { useRrWebRecorder } from "../../hooks/useRrWebRecorder";
 
 export const ConsumerPage = ({ children, title, loading }) => {
   const eventSlug = useReducedSubdomain();
@@ -15,7 +16,9 @@ export const ConsumerPage = ({ children, title, loading }) => {
     loading: eventLoading,
     error,
   } = useEvent({ eventId: eventSlug });
+
   useTitle(title ? `${title} | ${event?.name}` : event?.name);
+  useRrWebRecorder({ eventId: event?.id });
 
   if (eventLoading) {
     return <div>Loading...</div>;

--- a/app/components/RrwebPlayer/RrwebPlayer.jsx
+++ b/app/components/RrwebPlayer/RrwebPlayer.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from "react";
 import rrwebPlayer from "rrweb-player";
 import "rrweb-player/dist/style.css";
+import styles from "./RrwebPlayertrigger.module.css";
 
 export const RrwebPlayer = ({ events = [], config = {} }) => {
   const containerRef = useRef(null);
@@ -13,7 +14,7 @@ export const RrwebPlayer = ({ events = [], config = {} }) => {
       target: containerRef.current,
       props: {
         events,
-        width: 400,
+        // width: 400,
         skipInactive: true,
         inactiveColor: "var(--tblr-danger)",
 
@@ -28,5 +29,11 @@ export const RrwebPlayer = ({ events = [], config = {} }) => {
     };
   }, [events, config]);
 
-  return <div style={{ maxWidth: "100%" }} ref={containerRef} />;
+  return (
+    <div
+      style={{ maxWidth: "100%" }}
+      ref={containerRef}
+      className={styles.player}
+    />
+  );
 };

--- a/app/components/RrwebPlayer/RrwebPlayer.jsx
+++ b/app/components/RrwebPlayer/RrwebPlayer.jsx
@@ -14,6 +14,9 @@ export const RrwebPlayer = ({ events = [], config = {} }) => {
       props: {
         events,
         width: 400,
+        skipInactive: true,
+        inactiveColor: "var(--tblr-danger)",
+
         ...config,
       },
     });

--- a/app/components/RrwebPlayer/RrwebPlayer.jsx
+++ b/app/components/RrwebPlayer/RrwebPlayer.jsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useRef } from "react";
+import rrwebPlayer from "rrweb-player";
+import "rrweb-player/dist/style.css";
+
+export const RrwebPlayer = ({ events = [], config = {} }) => {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!containerRef.current || !events.length) return;
+
+    // Create player instance
+    const player = new rrwebPlayer({
+      target: containerRef.current,
+      props: {
+        events,
+        width: 400,
+        ...config,
+      },
+    });
+
+    return () => {
+      // rrweb-player doesn’t have an official destroy,
+      // but we can clear the container to avoid leaks
+      if (containerRef.current) containerRef.current.innerHTML = "";
+    };
+  }, [events, config]);
+
+  return <div style={{ maxWidth: "100%" }} ref={containerRef} />;
+};

--- a/app/components/RrwebPlayer/RrwebPlayerTrigger.jsx
+++ b/app/components/RrwebPlayer/RrwebPlayerTrigger.jsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Button, Spinner, Typography } from "tabler-react-2";
+import { useOffcanvas } from "tabler-react-2/dist/offcanvas";
+import { useParams } from "react-router-dom";
+
+import { useSession } from "../../hooks/useSession";
+import { RrwebPlayer } from "./RrwebPlayer";
+
+const { H3, Text } = Typography;
+
+// Usage: <RrwebPlayerTrigger sessionId="..." />
+// Renders a button that opens an offcanvas containing the rrweb player
+export const RrwebPlayerTrigger = ({
+  sessionId,
+  prompt = "View Session",
+  ...buttonProps
+}) => {
+  const { OffcanvasElement, offcanvas } = useOffcanvas({
+    offcanvasProps: { position: "end", size: 500, zIndex: 1051 },
+  });
+
+  const PlayerContent = () => {
+    const { eventId } = useParams();
+    const { session, loading, error } = useSession({ eventId, sessionId });
+
+    if (loading) return <Spinner />;
+    if (error)
+      return (
+        <Text className="text-danger">Failed to load session replay.</Text>
+      );
+    if (!session?.events?.length)
+      return <Text>Session has no recorded events.</Text>;
+
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <H3 className="mb-2">Session Replay</H3>
+        <div style={{ maxWidth: "100%" }}>
+          <RrwebPlayer events={session.events} />
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <>
+      {OffcanvasElement}
+      <Button
+        disabled={!sessionId}
+        onClick={() => offcanvas({ content: <PlayerContent /> })}
+        {...buttonProps}
+      >
+        {prompt}
+      </Button>
+    </>
+  );
+};
+
+export default RrwebPlayerTrigger;

--- a/app/components/RrwebPlayer/RrwebPlayertrigger.module.css
+++ b/app/components/RrwebPlayer/RrwebPlayertrigger.module.css
@@ -1,0 +1,3 @@
+.player .__PrivateStripeElement {
+  background: red !important;
+}

--- a/app/hooks/useFormBuilder.jsx
+++ b/app/hooks/useFormBuilder.jsx
@@ -29,10 +29,17 @@ export const useFormBuilder = (eventId) => {
     const pii = await getPII();
     try {
       const url = `/api/events/${eventId}/submission`;
+      // Read rrweb session id from sessionStorage if available
+      let sessionId = null;
+      try {
+        if (typeof sessionStorage !== "undefined") {
+          sessionId = sessionStorage.getItem("ep_rrweb_sessionId");
+        }
+      } catch (_) {}
       const res = await authFetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ values, shifts, pii }),
+        body: JSON.stringify({ values, shifts, pii, sessionId }),
       });
       const data = await res.json();
       setMutationLoading(false);

--- a/app/hooks/useRegistrationConsumer.jsx
+++ b/app/hooks/useRegistrationConsumer.jsx
@@ -20,9 +20,16 @@ export const useRegistrationConsumer = ({ eventId }) => {
 
   const submit = async (data) => {
     setMutationLoading(true);
+    // Read rrweb session id from sessionStorage if available
+    let sessionId = null;
+    try {
+      if (typeof sessionStorage !== "undefined") {
+        sessionId = sessionStorage.getItem("ep_rrweb_sessionId");
+      }
+    } catch (_) {}
     const promise = authFetch(key, {
       method: "POST",
-      body: JSON.stringify(data),
+      body: JSON.stringify({ ...data, sessionId }),
     })
       .then(async (r) => {
         if (!r.ok) throw new Error("Request failed");

--- a/app/hooks/useRrWebRecorder.jsx
+++ b/app/hooks/useRrWebRecorder.jsx
@@ -1,0 +1,262 @@
+import { useEffect, useRef, useState } from "react";
+import { u } from "../util/url";
+
+/** Simple POST JSON helper (no keepalive) */
+export const postJson = async (url, body) => {
+  const res = await fetch(u(url), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body ?? {}),
+  });
+  if (!res.ok) {
+    const t = await res.text().catch(() => "");
+    throw new Error(`POST ${url} failed: ${res.status} ${t}`);
+  }
+  return res.json();
+};
+
+/** Browser-safe base64 for UTF-8 strings */
+const toBase64 = (str) =>
+  typeof window === "undefined"
+    ? Buffer.from(str, "utf8").toString("base64")
+    : btoa(unescape(encodeURIComponent(str)));
+
+let rrwebRecordRef = null;
+const ensureRrweb = async () => {
+  if (!rrwebRecordRef) {
+    const mod = await import("rrweb");
+    rrwebRecordRef = mod.record;
+  }
+  return rrwebRecordRef;
+};
+
+/**
+ * useRrWebRecorder
+ * - Starts rrweb recording on mount
+ * - Creates session via POST /api/events/:eventId/sessions
+ * - Every `burstMs` uploads chunk to /api/events/:eventId/sessions/:sessionId
+ * - Caches chunks until session is created, then drains
+ * - Finalizes on UNLOAD/CLOSE without using keepalive
+ */
+export const useRrWebRecorder = ({
+  eventId,
+  instanceId, // optional
+  pageType, // optional
+  path, // optional
+  burstMs = 5000,
+} = {}) => {
+  const [sessionId, _setSessionId] = useState(null);
+  const sessionIdRef = useRef(null);
+  const setSessionId = (id) => {
+    sessionIdRef.current = id;
+    _setSessionId(id);
+  };
+
+  const startedAtRef = useRef(null);
+  const lastFlushAtRef = useRef(null);
+  const stopFnRef = useRef(null);
+  const intervalRef = useRef(null);
+
+  const eventsRef = useRef([]); // active buffer
+  const pendingRef = useRef([]); // queued before session id exists
+
+  const creatingRef = useRef(false);
+  const createdOnceRef = useRef(false);
+  const finalizingRef = useRef(false);
+
+  const buildPath = () =>
+    path || (typeof location !== "undefined" ? location.pathname : undefined);
+
+  const drainPending = async (sid) => {
+    if (!sid || pendingRef.current.length === 0) return;
+    const pending = pendingRef.current;
+    pendingRef.current = [];
+    for (const p of pending) {
+      await postJson(`/api/events/${eventId}/sessions/${sid}`, {
+        chunk: {
+          fileB64: p.fileB64,
+          filename: `rrweb-${sid}-${p.startedAt}.json`,
+          contentType: "application/json",
+          startedAt: p.startedAt,
+          endedAt: p.endedAt,
+        },
+        finalize: p.finalize,
+        terminationReason: p.terminationReason,
+        pageType,
+        path: buildPath(),
+      });
+    }
+  };
+
+  const flush = async ({ finalize = false, terminationReason = null } = {}) => {
+    if (finalizingRef.current) return;
+    if (eventsRef.current.length === 0 && !finalize) return;
+
+    // snapshot & clear buffer
+    const snapshot = eventsRef.current;
+    eventsRef.current = [];
+
+    const startedAt =
+      lastFlushAtRef.current ?? startedAtRef.current ?? Date.now();
+    const endedAt = Date.now();
+    lastFlushAtRef.current = endedAt;
+
+    const json = JSON.stringify({
+      startedAt,
+      endedAt,
+      count: snapshot.length,
+      events: snapshot,
+      meta: {
+        ua: typeof navigator !== "undefined" ? navigator.userAgent : "unknown",
+        path: buildPath(),
+        pageType: pageType || undefined,
+      },
+    });
+    const fileB64 = toBase64(json);
+
+    const sid = sessionIdRef.current;
+    if (!sid) {
+      pendingRef.current.push({
+        fileB64,
+        startedAt,
+        endedAt,
+        finalize,
+        terminationReason,
+      });
+      return;
+    }
+
+    await postJson(`/api/events/${eventId}/sessions/${sid}`, {
+      chunk: {
+        fileB64,
+        filename: `rrweb-${sid}-${startedAt}.json`,
+        contentType: "application/json",
+        startedAt,
+        endedAt,
+      },
+      finalize,
+      terminationReason,
+      pageType,
+      path: buildPath(),
+    });
+  };
+
+  const createSession = async () => {
+    if (creatingRef.current || createdOnceRef.current || !eventId) return;
+    creatingRef.current = true;
+    try {
+      const body = {
+        instanceId: instanceId || undefined,
+        pageType: pageType || undefined,
+        path: buildPath(),
+        metadata: {
+          startedAt: startedAtRef.current,
+          userAgent:
+            typeof navigator !== "undefined" ? navigator.userAgent : "unknown",
+        },
+      };
+      const json = await postJson(`/api/events/${eventId}/sessions`, body);
+      if (json?.id) {
+        setSessionId(json.id);
+        createdOnceRef.current = true;
+        await drainPending(json.id);
+      }
+    } catch {
+      // swallow; next tick/flush will retry while sessionIdRef is null
+    } finally {
+      creatingRef.current = false;
+    }
+  };
+
+  const start = async () => {
+    const record = await ensureRrweb();
+    startedAtRef.current = Date.now();
+
+    stopFnRef.current = record({
+      emit: (e) => {
+        eventsRef.current.push(e);
+      },
+      // sampling / recordCanvas can be configured here
+    });
+
+    // attempt session create ASAP
+    createSession();
+
+    // interval that never closes over stale state
+    intervalRef.current = setInterval(() => {
+      flush().catch(() => {});
+      if (!sessionIdRef.current && !creatingRef.current) {
+        createSession();
+      }
+    }, burstMs);
+
+    // lifecycle -> finalize
+    const onPageHide = () => finalize("UNLOAD");
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") finalize("UNLOAD");
+    };
+    const onBeforeUnload = () => finalize("CLOSE");
+
+    window.addEventListener("pagehide", onPageHide);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    window.addEventListener("beforeunload", onBeforeUnload);
+
+    // cleanup remover
+    return () => {
+      window.removeEventListener("pagehide", onPageHide);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener("beforeunload", onBeforeUnload);
+    };
+  };
+
+  const stop = async () => {
+    if (stopFnRef.current) {
+      stopFnRef.current();
+      stopFnRef.current = null;
+    }
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  };
+
+  const finalize = async (reason /* "UNLOAD" | "CLOSE" */) => {
+    if (finalizingRef.current) return;
+    finalizingRef.current = true;
+    try {
+      if (stopFnRef.current) {
+        stopFnRef.current();
+        stopFnRef.current = null;
+      }
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      await flush({ finalize: true, terminationReason: reason });
+      await drainPending(sessionIdRef.current);
+    } finally {
+      finalizingRef.current = false;
+    }
+  };
+
+  useEffect(() => {
+    if (!eventId) return;
+    let removeLifecycle = () => {};
+    (async () => {
+      removeLifecycle = await start();
+    })();
+    return () => {
+      // treat React unmount as a proper close
+      finalize("CLOSE").catch(() => {});
+      removeLifecycle?.();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventId, burstMs, pageType, path, instanceId]);
+
+  return {
+    sessionId,
+    flush: () => flush(),
+    finalize,
+    stop,
+  };
+};

--- a/app/hooks/useRrWebRecorder.jsx
+++ b/app/hooks/useRrWebRecorder.jsx
@@ -51,6 +51,17 @@ export const useRrWebRecorder = ({
   const setSessionId = (id) => {
     sessionIdRef.current = id;
     _setSessionId(id);
+    try {
+      if (id) {
+        // Store current session id for consumer flows to read when submitting
+        // Use sessionStorage so it resets on tab close
+        if (typeof sessionStorage !== "undefined") {
+          sessionStorage.setItem("ep_rrweb_sessionId", id);
+        }
+      }
+    } catch (_) {
+      // no-op if storage is unavailable
+    }
   };
 
   const startedAtRef = useRef(null);

--- a/app/hooks/useSession.jsx
+++ b/app/hooks/useSession.jsx
@@ -1,0 +1,27 @@
+import useSWR from "swr";
+import { authFetch } from "../util/url";
+
+const fetcher = (url) => authFetch(url).then((r) => r.json());
+
+// Read-only hook for a single session
+// Returns: { session, loading, error, refetch }
+export const useSession = ({ eventId, sessionId }) => {
+  const key =
+    eventId && sessionId ? `/api/events/${eventId}/sessions/${sessionId}` : null;
+
+  const {
+    data,
+    error,
+    isLoading,
+    mutate: refetch,
+  } = useSWR(key, fetcher);
+
+  // API returns the session object directly (not wrapped)
+  return {
+    session: data,
+    loading: isLoading,
+    error,
+    refetch,
+  };
+};
+

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -39,6 +39,7 @@ import { TeamsPage } from "./routes/events/[eventId]/registration/teams";
 import { CouponsPage } from "./routes/events/[eventId]/registration/coupons";
 import { RegistrationsPage } from "./routes/events/[eventId]/registration/registrations";
 import { SelectedInstanceProvider } from "../contexts/SelectedInstanceContext";
+import { EventSessionPage } from "./routes/events/[eventId]/session/[sessionId]";
 const useNewConversationPage = true;
 
 export default () => {
@@ -92,6 +93,11 @@ export default () => {
 
             <Route path="/events/:eventId" element={<Event />} />
             <Route path="/events" element={<Events />} />
+
+            <Route
+              path="/events/:eventId/session/:sessionId"
+              element={<EventSessionPage />}
+            />
 
             <Route
               path="/events/:eventId/financials"

--- a/app/src/routes/events/[eventId]/index.jsx
+++ b/app/src/routes/events/[eventId]/index.jsx
@@ -34,6 +34,7 @@ import { TeamJoinsCard } from "../../../../components/TeamJoinsCard/TeamJoinsCar
 import { VolunteerCapacityCard } from "../../../../components/VolunteerCapacityCard/VolunteerCapacityCard";
 import { CouponUsageCard } from "../../../../components/CouponUsageCard/CouponUsageCard";
 import { UpsellUsageCard } from "../../../../components/UpsellUsageCard/UpsellUsageCard";
+import RrwebPlayerTrigger from "../../../../components/RrwebPlayer/RrwebPlayerTrigger";
 
 const Divider = styled.div`
   background-color: var(--tblr-card-border-color);
@@ -46,7 +47,10 @@ export const Event = () => {
   const { eventId } = useParams();
   const { event, loading, error, refetch } = useEvent({ eventId });
   const { startTour } = useTourManager();
-  const [remainingOpen, setRemainingOpen] = useDbState(true, "remainingStepsOpen");
+  const [remainingOpen, setRemainingOpen] = useDbState(
+    true,
+    "remainingStepsOpen"
+  );
 
   const {
     eventStart,
@@ -79,6 +83,7 @@ export const Event = () => {
       }
     >
       <Row align="center" style={{ gap: 8 }} className="mb-3">
+        <RrwebPlayerTrigger sessionId="cmf8ib0o50001o2ohz32hno3k" />
         <Typography.H2 style={{ margin: 0 }}>Remaining Steps</Typography.H2>
         <Button
           ghost

--- a/app/src/routes/events/[eventId]/index.jsx
+++ b/app/src/routes/events/[eventId]/index.jsx
@@ -83,7 +83,6 @@ export const Event = () => {
       }
     >
       <Row align="center" style={{ gap: 8 }} className="mb-3">
-        <RrwebPlayerTrigger sessionId="cmf8k09vi000qo24z4sgsafcy" />
         <Typography.H2 style={{ margin: 0 }}>Remaining Steps</Typography.H2>
         <Button
           ghost

--- a/app/src/routes/events/[eventId]/index.jsx
+++ b/app/src/routes/events/[eventId]/index.jsx
@@ -83,7 +83,7 @@ export const Event = () => {
       }
     >
       <Row align="center" style={{ gap: 8 }} className="mb-3">
-        <RrwebPlayerTrigger sessionId="cmf8ib0o50001o2ohz32hno3k" />
+        <RrwebPlayerTrigger sessionId="cmf8k09vi000qo24z4sgsafcy" />
         <Typography.H2 style={{ margin: 0 }}>Remaining Steps</Typography.H2>
         <Button
           ghost

--- a/app/src/routes/events/[eventId]/session/[sessionId].jsx
+++ b/app/src/routes/events/[eventId]/session/[sessionId].jsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import { EventPage } from "../../../../../components/eventPage/EventPage";
+import { useSession } from "../../../../../hooks/useSession";
+import { Typography } from "tabler-react-2";
+import { RrwebPlayer } from "../../../../../components/RrwebPlayer/RrwebPlayer";
+
+export const EventSessionPage = () => {
+  const { eventId, sessionId } = useParams();
+  const { session, loading, error } = useSession({ eventId, sessionId });
+
+  return (
+    <EventPage title="Session" loading={loading} showHr={false}>
+      {error ? (
+        <Typography.Text className="text-danger">
+          Failed to load session replay.
+        </Typography.Text>
+      ) : !session?.events?.length ? (
+        <Typography.Text>Session has no recorded events.</Typography.Text>
+      ) : (
+        <div style={{ maxWidth: "100%" }}>
+          <RrwebPlayer events={session.events} />
+        </div>
+      )}
+    </EventPage>
+  );
+};
+
+export default EventSessionPage;
+


### PR DESCRIPTION
This pull request introduces a new session recording and tracking system for rrweb consumer sessions, including schema changes, new API endpoints, and logic to associate sessions with registrations and volunteer submissions. The main themes are database schema updates for session tracking, backend API routes for session creation and chunk uploads, and logic to link sessions with registrations and volunteer submissions.

**Session Recording and Tracking System**

* Added new `Session` and `SessionChunk` models to `schema.prisma`, supporting session metadata, chunked event storage, and associations with events, instances, registrations, volunteers, and geolocation. Includes new enum `SessionTerminationReason`.
* Created migration scripts to add the `Session` and `SessionChunk` tables, relevant indices, foreign keys, and later removed the direct `fileId` column from `Session` (now handled via `SessionChunk`). [[1]](diffhunk://#diff-46cf8aa70977a432e0f109db4d0e35e28130712a6c1af0d82d3fa25c2a8ae352R1-R40) [[2]](diffhunk://#diff-84351be96d6264ad290ff5df0c8e42eb6ec9ce14b3f9ea840555d388c8a9c672R1-R37) [[3]](diffhunk://#diff-ab2cdd4f23751c8807edb414d751d8600f64d334c529eeff19d711c7932b5d20R1-R2) [[4]](diffhunk://#diff-be80a01372eda879df4404752193c9e8c90f8f8642ba4e9241052b4477aaa36cR1-R11)

**API Endpoints for Session Management**

* Added `POST /api/events/:eventId/sessions` to create a new session with metadata, and `POST/GET /api/events/:eventId/sessions/:sessionId` to upload session chunks and retrieve merged session event data. ([api/routes/events/[eventId]/sessions/index.jsR1-R48](diffhunk://#diff-8e1539afe595413e2086b4a6b6cda678c9405e978163828e8203d540c2287728R1-R48), [api/routes/events/[eventId]/sessions/[sessionId].jsR1-R142](diffhunk://#diff-8fc30651a013ecb6b37e12a262a273d62f29a24624b457129200deaf24a3eec9R1-R142))

**Registration and Submission Linkage**

* Updated registration and volunteer submission endpoints to accept an optional `sessionId`, linking the rrweb session to the newly created registration or volunteer response and marking the session as converted. ([api/routes/events/[eventId]/registration/consumer.jsR19-R20](diffhunk://#diff-43047fd83f931800128391d3bf8c3d86803127f3028c355a54257662bba5e3e7R19-R20), [api/routes/events/[eventId]/registration/consumer.jsR388-R402](diffhunk://#diff-43047fd83f931800128391d3bf8c3d86803127f3028c355a54257662bba5e3e7R388-R402), [api/routes/events/[eventId]/submission/index.jsR16-R25](diffhunk://#diff-f33c24da81eb911713a9c4c3c6eb2efb432cecba657ca5d14dcb058c520173c3R16-R25), [api/routes/events/[eventId]/submission/index.jsR146-R161](diffhunk://#diff-f33c24da81eb911713a9c4c3c6eb2efb432cecba657ca5d14dcb058c520173c3R146-R161))

**File Upload Improvements**

* Improved the `uploadFile` utility to handle base64url normalization, ensure correct content length, and use safer S3 key naming. Added a test script for file upload. [[1]](diffhunk://#diff-4a19d66839d92b8e39d1af8cbdf6f9ec0910b908604c19d20efca2050b8c466bL101-L117) [[2]](diffhunk://#diff-e78a3acc668ecc0fd07680ceddbe2cc536cd0631f409b506eef751854a10ab2eR1-R17)

**Schema Relationship Updates**

* Added `Session` relation fields to `Geolocation`, `File`, `Event`, `EventInstance`, `Registration`, and `VolunteerRegistration` models to support efficient querying and association. [[1]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdR253) [[2]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdR438) [[3]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdR499) [[4]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdR625-R626) [[5]](diffhunk://#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdR1113)

Let me know if you want to walk through the session API flows or discuss the schema changes in more detail!